### PR TITLE
feat: benchmark all models (with `--all` flag)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.idea/
+.vscode/

--- a/whisper/benchmark.py
+++ b/whisper/benchmark.py
@@ -1,5 +1,6 @@
 # Copyright © 2023 Apple Inc.
 
+import sys
 import time
 
 import mlx.core as mx
@@ -48,46 +49,58 @@ def everything():
 
 
 if __name__ == "__main__":
-    feat_time = timer(feats)
-    print(f"Feature time {feat_time:.3f}")
-    mels = feats()[None]
-    tokens = mx.array(
-        [
-            50364,
-            1396,
-            264,
-            665,
-            5133,
-            23109,
-            25462,
-            264,
-            6582,
-            293,
-            750,
-            632,
-            42841,
-            292,
-            370,
-            938,
-            294,
-            4054,
-            293,
-            12653,
-            356,
-            50620,
-            50620,
-            23563,
-            322,
-            3312,
-            13,
-            50680,
-        ],
-        mx.int32,
-    )[None]
-    model = load_models.load_model("tiny")
-    model_forward_time = timer(model_forward, model, mels, tokens)
-    print(f"Model forward time {model_forward_time:.3f}")
-    decode_time = timer(decode, model, mels)
-    print(f"Decode time {decode_time:.3f}")
-    everything_time = timer(everything)
-    print(f"Everything time {everything_time:.3f}")
+
+    # get command line arguments without 3rd party libraries
+    # the command line argument to benchmark all models is "all"
+    models = ["tiny"]
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "--all":
+            models = ["tiny", "small", "medium", "large"]
+
+    for model_name in models:
+        feat_time = timer(feats)
+
+        print(f"\nModel: {model_name.upper()}")
+        print(f"\nFeature time {feat_time:.3f}")
+        mels = feats()[None]
+        tokens = mx.array(
+            [
+                50364,
+                1396,
+                264,
+                665,
+                5133,
+                23109,
+                25462,
+                264,
+                6582,
+                293,
+                750,
+                632,
+                42841,
+                292,
+                370,
+                938,
+                294,
+                4054,
+                293,
+                12653,
+                356,
+                50620,
+                50620,
+                23563,
+                322,
+                3312,
+                13,
+                50680,
+            ],
+            mx.int32,
+        )[None]
+        model = load_models.load_model(f"{model_name}")
+        model_forward_time = timer(model_forward, model, mels, tokens)
+        print(f"Model forward time {model_forward_time:.3f}")
+        decode_time = timer(decode, model, mels)
+        print(f"Decode time {decode_time:.3f}")
+        everything_time = timer(everything)
+        print(f"Everything time {everything_time:.3f}")
+        print(f"\n{'-----' * 10}\n")


### PR DESCRIPTION
While running a benchmark, if the user adds the `--all` flag,

```
python benchmark.py  --all
```

Then, all the models - `[tiny, base, small, medium, large]` will be benchmarked.

Also, updated `.gitignore` to ignore `.vscode/` and `.idea/`

<img width="529" alt="image" src="https://github.com/ml-explore/mlx-examples/assets/31769894/f3ca4f2d-32b7-46a2-b6eb-3f97118d9c32">
