### PR TITLE
fix: typo in variable name

### DIFF
--- a/stable_diffusion/stable_diffusion/vae.py
+++ b/stable_diffusion/stable_diffusion/vae.py
@@ -257,7 +257,7 @@ class Autoencoder(nn.Module):
 
     def __call__(self, x, key=None):
         x = self.encoder(x)
-        x = self.query_proj(x)
+        x = self.quant_proj(x)
 
         mean, logvar = x.split(2, axis=-1)
         std = mx.exp(0.5 * logvar)


### PR DESCRIPTION
This layer name is quant rather than query