### PR TITLE
fix: fix issue #54, use CPU device to load the Torch model

### DIFF
--- a/llama/convert.py
+++ b/llama/convert.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     parser.add_argument("output_file")
     args = parser.parse_args()
 
-    state = torch.load(args.torch_weights)
+    state = torch.load(args.torch_weights, map_location=torch.device('cpu'))
     np.savez(
         args.output_file,
         **{k: v for k, v in starmap(map_torch_to_mlx, state.items()) if k is not None}


### PR DESCRIPTION
If the model is large, for example, llama-2-13b, the convert.py will try to load the model with CUDA device and reports an error.

```shell
 ✘ python3 ./convert.py ../../llama/llama-2-13b/consolidated.00.pth llama-2-13b
Traceback (most recent call last):
  File "/Users/starfish/working/llm/mlx-examples/llama/./convert.py", line 49, in <module>
    state = torch.load(args.torch_weights)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/torch/serialization.py", line 1014, in load
    return _load(opened_zipfile,
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/torch/serialization.py", line 1422, in _load
    result = unpickler.load()
             ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/torch/serialization.py", line 1392, in persistent_load
    typed_storage = load_tensor(dtype, nbytes, key, _maybe_decode_ascii(location))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/torch/serialization.py", line 1366, in load_tensor
    wrap_storage=restore_location(storage, location),
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/torch/serialization.py", line 381, in default_restore_location
    result = fn(storage, location)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/torch/serialization.py", line 274, in _cuda_deserialize
    device = validate_cuda_device(location)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/torch/serialization.py", line 258, in validate_cuda_device
    raise RuntimeError('Attempting to deserialize object on a CUDA '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```

This patch fix the problem by using the CPU device to load the Torch model.