### PR TITLE
Whisper - fixed errors in test and benchmark.

### DIFF
--- a/whisper/benchmark.py
+++ b/whisper/benchmark.py
@@ -9,6 +9,7 @@ from whisper import load_models
 from whisper import audio
 from whisper import decoding
 from whisper import transcribe
+from whisper.decoding import DecodingOptions
 
 audio_file = "whisper/assets/ls_test.flac"
 
@@ -41,11 +42,13 @@ def model_forward(model, mels, tokens):
 
 
 def decode(model, mels):
-    return decoding.decode(model, mels)
+    options = DecodingOptions(fp16 = False)
+    return decoding.decode(model, mels, options)
 
 
 def everything():
-    return transcribe(audio_file)
+    options = DecodingOptions(fp16 = False)
+    return transcribe(audio_file, **options.__dict__)
 
 
 if __name__ == "__main__":

--- a/whisper/test.py
+++ b/whisper/test.py
@@ -5,13 +5,11 @@ import unittest
 import mlx.core as mx
 import numpy as np
 import os
-import subprocess
 import torch
 
 import whisper
 import whisper.audio as audio
 import whisper.load_models as load_models
-import whisper.torch_whisper as torch_whisper
 import whisper.decoding as decoding
 
 
@@ -62,7 +60,7 @@ class TestWhisper(unittest.TestCase):
         dims = mlx_model.dims
         mels = mx.array(np.random.randn(1, 3_000, dims.n_mels), mx.float16)
         tokens = mx.array(np.random.randint(0, dims.n_vocab, (1, 20)), mx.int32)
-        logits = mlx_model(mels, tokens)
+        logits = mlx_model(mels, tokens).astype(mx.float16)
         self.assertEqual(logits.dtype, mx.float16)
 
 


### PR DESCRIPTION
Current version of [whisper/test.py](https://github.com/ml-explore/mlx-examples/blob/main/whisper/test.py) may cause `test_fp16(self)` to fail, fixed.
```
FAIL: test_fp16 (__main__.TestWhisper.test_fp16)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mlx-examples/whisper/test.py", line 64, in test_fp16
    self.assertEqual(logits.dtype, mx.float16)
AssertionError: float32 != float16
```
Current version of [whisper/benchmark.py](https://github.com/ml-explore/mlx-examples/blob/main/whisper/benchmark.py) may cause type error in `decode(model, mels)` and `everything()`, fixed.
```
  File "/mlx-examples/whisper/whisper/decoding.py", line 550, in _get_audio_features
    raise TypeError(
TypeError: audio_features has an incorrect dtype: float32
```