### PR TITLE
fix "request access" form url for Llama models

### DIFF
--- a/lora/README.md
+++ b/lora/README.md
@@ -24,7 +24,7 @@ tar -xf mistral-7B-v0.1.tar
 ```
 
 If you do not have access to the Llama weights you will need to [request
-access](https://docs.google.com/forms/d/e/1FAIpQLSfqNECQnMkycAp2jP4Z9TFX0cGR4uf7b_fBxjY_OjhJILlKGA/viewform)
+access](https://ai.meta.com/resources/models-and-libraries/llama-downloads/)
 from Meta.
 
 Convert the model with:


### PR DESCRIPTION
this PR makes the docs on Llama model downloads consistent for lora and llama examples.