### PR TITLE
Fix typo in stable_diffusion README

### DIFF
--- a/stable_diffusion/README.md
+++ b/stable_diffusion/README.md
@@ -27,7 +27,7 @@ Usage
 ------
 
 Although each component in this repository can be used by itself, the fastest
-way to get started is by using the `StableDiffusion` class from the `diffusion`
+way to get started is by using the `StableDiffusion` class from the `stable_diffusion`
 module.
 
 ```python


### PR DESCRIPTION
 - Correct module name from **diffusion** to **stable_diffusion**.