### PR TITLE
feat: stop phi-2 output at <|endoftext|>

### DIFF
--- a/phi2/phi2.py
+++ b/phi2/phi2.py
@@ -200,8 +200,12 @@ if __name__ == "__main__":
     print("[INFO] Generating with Phi-2...", flush=True)
     print(args.prompt, end="", flush=True)
 
+    end_of_response = tokenizer.encode("<|endoftext|>")[0]
+
     tokens = []
     for token, _ in zip(generate(prompt, model), range(args.max_tokens)):
+        if token.item() == end_of_response:
+            break
         tokens.append(token)
 
         if (len(tokens) % 10) == 0:


### PR DESCRIPTION
I'm not 100% sure this is correct, but it seems to help

stop the output of phi-2 when "<|endoftext|>" appears
