### PR TITLE
phi-2: fix --temp/--seed arguments.

### DIFF
--- a/phi2/phi2.py
+++ b/phi2/phi2.py
@@ -201,7 +201,7 @@ if __name__ == "__main__":
     print(args.prompt, end="", flush=True)
 
     tokens = []
-    for token, _ in zip(generate(prompt, model), range(args.max_tokens)):
+    for token, _ in zip(generate(prompt, model, args.temp), range(args.max_tokens)):
         tokens.append(token)
 
         if (len(tokens) % 10) == 0:


### PR DESCRIPTION
`seed` was not being passed to generate(). 

This quick fix will let folks experiment with `--temp/--seed`!