### PR TITLE
Use config.json, add model_type

### DIFF
--- a/mistral/convert.py
+++ b/mistral/convert.py
@@ -1,6 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 import argparse
+import json
 import numpy as np
 from pathlib import Path
 import torch
@@ -22,3 +23,10 @@ if __name__ == "__main__":
         str(model_path / "weights.npz"),
         **{k: v.to(torch.float16).numpy() for k, v in state.items()}
     )
+
+    # Save config.json with model_type
+    with open(model_path / "params.json", "r") as f:
+        config = json.loads(f.read())
+        config["model_type"] = "mistral"
+    with open(model_path / "config.json", "w") as f:
+        json.dump(config, f, indent=4)

--- a/mistral/mistral.py
+++ b/mistral/mistral.py
@@ -192,9 +192,10 @@ class Tokenizer:
 def load_model(folder: str, dtype=mx.float16):
     model_path = Path(folder)
     tokenizer = Tokenizer(str(model_path / "tokenizer.model"))
-    with open(model_path / "params.json", "r") as f:
+    with open(model_path / "config.json", "r") as f:
         config = json.loads(f.read())
-        config.pop("sliding_window")
+        config.pop("sliding_window", None)
+        config.pop("model_type", None)
         model_args = ModelArgs(**config)
     weights = mx.load(str(model_path / "weights.npz"))
     weights = tree_unflatten(list(weights.items()))


### PR DESCRIPTION
This would go with PRs like this one to the model repos: https://huggingface.co/mlx-community/mistral-7B-v0.1/discussions/7

The advantages of standardizing on `config.json` instead of `params.json`, and adding a `model_type` field, would be:

- Better compatibility with repos in the Hugging Face Hub, easier retrieval of stats.
- Easy (hopefully) support of existing safetensors repos when https://github.com/ml-explore/mlx/pull/215 is ready. IIUC, Mistral safetensors files should work out of the box.
- Easier election of inference code down the line, based on `model_type`.