### PR TITLE
Add support for byt5 models

### DIFF
--- a/t5/hf_t5.py
+++ b/t5/hf_t5.py
@@ -1,6 +1,6 @@
 import argparse
 
-from transformers import AutoTokenizer, T5EncoderModel, T5ForConditionalGeneration
+from transformers import AutoTokenizer, T5EncoderModel, AutoModelForSeq2SeqLM
 
 
 def embed(t5_model: str):
@@ -25,7 +25,7 @@ def embed(t5_model: str):
 def generate(t5_model: str):
     prompt = "translate English to German: As much as six inches of rain could fall in the New York City region through Monday morning, and officials warned of flooding along the coast."
     tokenizer = AutoTokenizer.from_pretrained(t5_model)
-    torch_model = T5ForConditionalGeneration.from_pretrained(t5_model)
+    torch_model = AutoModelForSeq2SeqLM.from_pretrained(t5_model)
     torch_tokens = tokenizer(prompt, return_tensors="pt", padding=True).input_ids
     outputs = torch_model.generate(torch_tokens, do_sample=False, max_length=512)
     print(tokenizer.decode(outputs[0], skip_special_tokens=True))

--- a/t5/t5.py
+++ b/t5/t5.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Tuple
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
-from mlx.utils import tree_map, tree_flatten, tree_unflatten
+from mlx.utils import tree_map, tree_unflatten
 from transformers import T5Config, AutoTokenizer
 
 


### PR DESCRIPTION
The t5 example doesn't support the ByT5 series ([paper](https://arxiv.org/abs/2105.13626)) because it uses more layers in the decoder than in the encoder. Also, for some reason, we have to use `AutoTokenizer` instead of the `T5Tokenizer`.

The model is not fine-tuned, so the output is garbage, but I checked it matches HF's.

```sh
$ export MODEL="google/byT5-small" && python convert.py --dtype float32 --model $MODEL && python t5.py --model $MODEL --prompt "Life is like a box of chocolates."
Saving weights to google-byT5-small.npz
[INFO] Generating with T5...
Input:  Life is like a box of chocolates.
ÿ chocolates chocolates chocolates chocolates chocolates chocolates chocolates chocolates chocolates
Time: 0.33 seconds, tokens/s: 298.93
```

I also checked with [this](https://huggingface.co/kaiyuy/leandojo-lean4-tacgen-byt5-small) fine-tuned model:

```sh
$ export MODEL="kaiyuy/leandojo-lean4-tacgen-byt5-small" && python convert.py --dtype float32 --model $MODEL && python t5.py --model $MODEL --prompt "a b : ℕ
⊢ a + b = b + a"
Saving weights to kaiyuy-leandojo-lean4-tacgen-byt5-small.npz
[INFO] Generating with T5...
Input:  a b : ℕ
⊢ a + b = b + a
rw [add_comm, add_comm]
Time: 0.14 seconds, tokens/s: 173.76
```
