### PR TITLE
update path to load weights

### DIFF
--- a/llms/phi2/phi2.py
+++ b/llms/phi2/phi2.py
@@ -169,7 +169,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--model-path",
         type=str,
-        default="phi-2",
+        default=".",
         help="The path to the model weights",
     )
     parser.add_argument(


### PR DESCRIPTION
Since the reorg in #145, the paths to the load the model weights need to be updated. This PR updates the path to load the weights for `phi2`.

<img width="938" alt="image" src="https://github.com/ml-explore/mlx-examples/assets/31466137/4fb8e218-0c9f-4289-92bf-0536081d0659">

cc @awni 