### PR TITLE
1. Add user warning for sequences over 2048 tokens in iterate_batches.

### DIFF
--- a/lora/lora.py
+++ b/lora/lora.py
@@ -209,6 +209,10 @@ def iterate_batches(dset, tokenizer, batch_size, train=False):
                 for j in range(batch_size)
             ]
             lengths = [len(x) for x in batch]
+            
+            # Check if any sequence is longer than 2048 tokens
+            if max(lengths) > 2048:
+                print("Warning: Some sequences are longer than 2048 tokens. Consider pre-splitting your data to save memory.")
 
             # Pad to the max length
             batch_arr = np.zeros((batch_size, max(lengths)), np.int32)


### PR DESCRIPTION
In response to our earlier discussion, I have removed the truncation logic in `iterate_batches`. Now, instead of truncating, the function issues a warning for sequences exceeding 2048 tokens, alerting users to potential memory issues and encouraging pre-splitting of data.