### PR TITLE
QWEN: Fix unsupported ScalarType BFloat16

### DIFF
--- a/llms/qwen/convert.py
+++ b/llms/qwen/convert.py
@@ -60,7 +60,7 @@ def convert(args):
         args.model, trust_remote_code=True, torch_dtype=torch.float16
     )
     state_dict = model.state_dict()
-    weights = {replace_key(k): v.numpy() for k, v in state_dict.items()}
+    weights = {replace_key(k): (v.numpy() if v.dtype != torch.bfloat16 else v.to(torch.float32).numpy()) for k, v in state_dict.items()}
     config = model.config.to_dict()
 
     if args.quantize:


### PR DESCRIPTION
Fix unsupported ScalarType BFloat16.

Env: Mac M1 Ultra
torch: torch-2.0.0, metal
Apple clang version 15.0.0 (clang-1500.0.40.1)
Target: arm64-apple-darwin23.1.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin

```
Traceback (most recent call last):
  File "/Volumes/v1/models/mlx-examples-main/llms/qwen/convert.py", line 110, in <module>
    convert(args)
  File "/Volumes/v1/models/mlx-examples-main/llms/qwen/convert.py", line 63, in convert
    weights = {replace_key(k): v.numpy() for k, v in state_dict.items()}
  File "/Volumes/v1/models/mlx-examples-main/llms/qwen/convert.py", line 63, in <dictcomp>
    weights = {replace_key(k): v.numpy() for k, v in state_dict.items()}
TypeError: Got unsupported ScalarType BFloat16
```

Fix: almost the same as [#10](https://github.com/ml-explore/mlx-examples/pull/10/commits/429ddb30dca199c9cfbfe2280cf47875cc3f0be9)