### PR TITLE
fix: Add numpy to CIFAR's requirements.txt

### DIFF
--- a/cifar/requirements.txt
+++ b/cifar/requirements.txt
@@ -1,2 +1,3 @@
 mlx
 mlx-data
+numpy


### PR DESCRIPTION
I noticed that CIFAR example is missing `numpy` in requirements.txt