### PR TITLE
chore: fix the load quantization model for deepseek coder

### DIFF
--- a/llms/deepseek-coder/deepseek_coder.py
+++ b/llms/deepseek-coder/deepseek_coder.py
@@ -244,7 +244,7 @@ def load_model(model_path: str):
 
     model = DeepseekCoder(model_args)
     weights = mx.load(str(model_path / "weights.npz"))
-    if quantization := config.get("quantization", False):
+    if quantization:
         nn.QuantizedLinear.quantize_module(model, **quantization)
     model.update(tree_unflatten(list(weights.items())))
 

--- a/llms/deepseek-coder/deepseek_coder.py
+++ b/llms/deepseek-coder/deepseek_coder.py
@@ -244,7 +244,7 @@ def load_model(model_path: str):
 
     model = DeepseekCoder(model_args)
     weights = mx.load(str(model_path / "weights.npz"))
-    if quantization:
+    if quantization is not None:
         nn.QuantizedLinear.quantize_module(model, **quantization)
     model.update(tree_unflatten(list(weights.items())))
 


### PR DESCRIPTION
While I was trying to upload the quantized deepseek code model to mlx-community, noticed the deepseek code example wouldn't load the quantized model because the quantization config popped up during loading of model arguments. The following "config.get("quantization", False)" will always return false, even for the quantized model.