### PR TITLE
chore: make the Deepseek example compatible with Yi models.

### DIFF
--- a/llms/deepseek-coder/convert.py
+++ b/llms/deepseek-coder/convert.py
@@ -44,7 +44,7 @@ def convert(args):
     config = model.config.to_dict()
 
     state_dict = model.state_dict()
-    tokenizer = AutoTokenizer.from_pretrained(str(hf_path), trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(str(hf_path), trust_remote_code=True, use_fast=False)
 
     # things to change
     # 1. there's no "model." in the weight names
@@ -84,7 +84,7 @@ def convert(args):
 
     weights = {k: v.numpy() for k, v in state_dict.items()}
 
-    config["rope_scaling_factor"] = config["rope_scaling"]["factor"]
+    config["rope_scaling_factor"] = config["rope_scaling"]["factor"] if config["rope_scaling"] is not None else 1.0
     keep_keys = set(
         [
             "vocab_size",
@@ -96,6 +96,7 @@ def convert(args):
             "rms_norm_eps",
             "intermediate_size",
             "rope_scaling_factor",
+            "rope_theta"
         ]
     )
     for k in list(config.keys()):
@@ -151,4 +152,4 @@ if __name__ == "__main__":
     tokenizer.save_pretrained(mlx_path)
     with open(mlx_path / "config.json", "w") as f:
         config["model_type"] = "deepseek_coder"
-        json.dump(config, f, indent=4)
+        json.dump(config, f, indent=4)% 

--- a/llms/deepseek-coder/convert.py
+++ b/llms/deepseek-coder/convert.py
@@ -152,4 +152,4 @@ if __name__ == "__main__":
     tokenizer.save_pretrained(mlx_path)
     with open(mlx_path / "config.json", "w") as f:
         config["model_type"] = "deepseek_coder"
-        json.dump(config, f, indent=4)% 
+        json.dump(config, f, indent=4)

--- a/llms/deepseek-coder/deepseek_coder.py
+++ b/llms/deepseek-coder/deepseek_coder.py
@@ -248,7 +248,7 @@ def load_model(model_path: str):
         nn.QuantizedLinear.quantize_module(model, **quantization)
     model.update(tree_unflatten(list(weights.items())))
 
-    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True, use_fast=False)
     return model, tokenizer
 
 


### PR DESCRIPTION
Before consolidating all the models similar to llamas into the llama example, just make some minor changes in the DeepSeek example so that people can use it to run HF format models with autoTokenizer if they want to try out some hf format models. for example https://github.com/ml-explore/mlx-examples/issues/204