### PR TITLE
Update README.md to fix --hf-model param call.

### DIFF
--- a/llms/hf_llm/README.md
+++ b/llms/hf_llm/README.md
@@ -61,7 +61,7 @@ a model directory (which you can optionally also upload to Hugging Face).
 For example, to make 4-bit quantized a model, run:
 
 ```
-python convert.py --hf-model <hf_repo> -q
+python convert.py --hf-path <hf_repo> -q
 ```
 
 For more options run:


### PR DESCRIPTION
In `llms/hf_llm` the readme refers to `--hf-model` as a parameter to use to grab a model for conversion. This param doesn't exist, it's `--hf-path`. I've updated the readme to fix it.