### PR TITLE
Handle receiving 0 tokens gracefully

### DIFF
--- a/llms/hf_llm/generate.py
+++ b/llms/hf_llm/generate.py
@@ -43,6 +43,9 @@ def generate(
         s = tokenizer.decode(tokens)
         print(s[skip:], end="", flush=True)
         skip = len(s)
+    if (len(tokens) == 0):
+        print("No tokens generated for this prompt")
+        return
     print(tokenizer.decode(tokens)[skip:], flush=True)
     gen_time = time.time() - tic
     print("=" * 10)

--- a/llms/hf_llm/generate.py
+++ b/llms/hf_llm/generate.py
@@ -43,12 +43,12 @@ def generate(
         s = tokenizer.decode(tokens)
         print(s[skip:], end="", flush=True)
         skip = len(s)
-    if len(tokens) == 0:
-        print("No tokens generated for this prompt")
-        return
     print(tokenizer.decode(tokens)[skip:], flush=True)
     gen_time = time.time() - tic
     print("=" * 10)
+    if len(tokens) == 0:
+        print("No tokens generated for this prompt")
+        return
     prompt_tps = prompt.size / prompt_time
     gen_tps = (len(tokens) - 1) / gen_time
     print(f"Prompt: {prompt_tps:.3f} tokens-per-sec")

--- a/llms/hf_llm/generate.py
+++ b/llms/hf_llm/generate.py
@@ -43,7 +43,7 @@ def generate(
         s = tokenizer.decode(tokens)
         print(s[skip:], end="", flush=True)
         skip = len(s)
-    if (len(tokens) == 0):
+    if len(tokens) == 0:
         print("No tokens generated for this prompt")
         return
     print(tokenizer.decode(tokens)[skip:], flush=True)


### PR DESCRIPTION
When using TinyLlama i've run into the case where we receive 0 tokens for a prompt. The user is shown an ambiguous error. This PR improves that to inform the user what has happened.

### Old
#### Command
` 
python generate.py --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --prompt "What makes the sky blue?"
`
#### Response
```
Fetching 8 files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:00<00:00, 114130.72it/s]

==========
Traceback (most recent call last):
  File "/Users/ChristianOld/Documents/Projects/LLM/mlx-examples/llms/hf_llm/generate.py", line 93, in <module>
    generate(model, tokenizer, args.prompt, args.max_tokens, args.temp)
  File "/Users/ChristianOld/Documents/Projects/LLM/mlx-examples/llms/hf_llm/generate.py", line 56, in generate
    prompt_tps = prompt.size / prompt_time
                               ^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'prompt_time' where it is not associated with a value

```

### New

#### Command
` 
python generate.py --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --prompt "What makes the sky blue?"
`
#### Response
```
Fetching 8 files: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:00<00:00, 30202.01it/s]

==========
No tokens generated for this prompt
```

