### PR TITLE
add numpy as a requirement to run lora.py

### DIFF
--- a/lora/lora.py
+++ b/lora/lora.py
@@ -5,13 +5,13 @@ import json
 import math
 import time
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List
 
 import mlx.core as mx
 import mlx.nn as nn
 import mlx.optimizers as optim
 import numpy as np
-from mlx.utils import tree_flatten, tree_map, tree_unflatten
+from mlx.utils import tree_flatten, tree_unflatten
 from models import LoRALinear, Model, ModelArgs
 from sentencepiece import SentencePieceProcessor
 

--- a/lora/requirements.txt
+++ b/lora/requirements.txt
@@ -1,3 +1,4 @@
 mlx>=0.0.7
 sentencepiece
 torch
+numpy


### PR DESCRIPTION
Running the `convert.py` script in the lora example gives this error. I added numpy as a dependency.

```
 python convert.py \
    --torch-path mistral-7B-v0.1 \
    --mlx-path mistral-7B-v0.1-mlx
```

yields this error:
```
Traceback (most recent call last):
  File "/Users/lawrence.wu/github/mlx-examples/lora/convert.py", line 11, in <module>
    import numpy as np
```