### PR TITLE
Add -local flag to llms/hf_llm/convert.py for reading source HF models from filesystem.

### DIFF
--- a/llms/hf_llm/convert.py
+++ b/llms/hf_llm/convert.py
@@ -183,5 +183,5 @@ if __name__ == "__main__":
     with open(mlx_path / "config.json", "w") as fid:
         json.dump(config, fid, indent=4)
 
-    if args.upload_name is not None and args.local is not False:
+    if args.upload_name is not None and not args.local:
         upload_to_hub(mlx_path, args.upload_name, args.hf_path)


### PR DESCRIPTION
This PR is to add a local flag (-l, --local) to convert.py to enable the reading of HF Models already on the filesystem during a conversion operation. Currently the script has to download the model weights from HF directly before beginning the conversion to MLX format. 

Setting the --local flag disables uploads to huggingface during conversion as the hf_path argument would not specify the original model in the modelcard. 