### PR TITLE
Fix use of undefined args in generate function in phi-2 example

### DIFF
--- a/llms/phi2/generate.py
+++ b/llms/phi2/generate.py
@@ -16,7 +16,7 @@ def generate(
     temp: float = 0.0,
 ):
     print("[INFO] Generating with Phi-2...", flush=True)
-    print(args.prompt, end="", flush=True)
+    print(prompt, end="", flush=True)
     prompt = tokenizer(
         prompt,
         return_tensors="np",
@@ -30,8 +30,8 @@ def generate(
     tokens = []
     skip = 0
     for token, n in zip(
-        phi2.generate(prompt, model, args.temp),
-        range(args.max_tokens),
+        phi2.generate(prompt, model, temp),
+        range(max_tokens),
     ):
         if token == tokenizer.eos_token_id:
             break

--- a/llms/phi2/phi2.py
+++ b/llms/phi2/phi2.py
@@ -1,4 +1,3 @@
-import argparse
 import glob
 import inspect
 import json


### PR DESCRIPTION
Currently, the `generate.py` accidentally works because `generate` is called in `main` where `args` is within the scope of the main function.