### PR TITLE
chore(lora): remove quantization config for fuse the quant model

### DIFF
--- a/lora/fuse.py
+++ b/lora/fuse.py
@@ -66,6 +66,10 @@ if __name__ == "__main__":
 
     model.update_modules(tree_unflatten(fused_linears))
     weights = dict(tree_flatten(model.parameters()))
+
+    if quantization := config.get("quantization", None):
+        config.pop("quantization")
+
     utils.save_model(args.save_path, weights, tokenizer._tokenizer, config)
 
     if args.upload_name is not None:


### PR DESCRIPTION
For the fuse qlora adapter weight, the quantization configuration will cause the fused model to fail to load. I haven't tested it locally yet, but this is the issue I had in the past when playing around with merging Lora.