### PR TITLE
lora.py - Incorrect assignment when padding zeros

### DIFF
--- a/lora/lora.py
+++ b/lora/lora.py
@@ -186,7 +186,7 @@ def iterate_batches(dset, tokenizer, batch_size, train=False):
                 )
 
             # Pad to the max length
-            batch_arr = np.zeros((batch_size, max(lengths)), np.int64)
+            batch_arr = np.zeros((batch_size, max(lengths)), np.int32)
             for j in range(batch_size):
                 batch_arr[j, : lengths[j]] = np.array(batch[j])
             batch = mx.array(batch_arr)

--- a/lora/lora.py
+++ b/lora/lora.py
@@ -186,9 +186,9 @@ def iterate_batches(dset, tokenizer, batch_size, train=False):
                 )
 
             # Pad to the max length
-            batch_arr = np.zeros((batch_size, max(lengths)), np.int32)
+            batch_arr = np.zeros((batch_size, max(lengths)), np.int64)
             for j in range(batch_size):
-                batch_arr[j, : lengths[j]] = batch[j]
+                batch_arr[j, : lengths[j]] = np.array(batch[j])
             batch = mx.array(batch_arr)
             yield batch[:, :-1], batch[:, 1:], mx.array(lengths)
 


### PR DESCRIPTION
When zeros are padded to training samples assignment is being made between numpy array and mlx array. This causes an exception. This PR simply corrects it.