### PR TITLE
Stable Diffusion: Input image downsampling

### DIFF
--- a/stable_diffusion/README.md
+++ b/stable_diffusion/README.md
@@ -67,7 +67,7 @@ Image 2 Image
 There is also the option of generating images based on another image using the
 example script `image2image.py`. To do that an image is first encoded using the
 autoencoder to get its latent representation and then noise is added according
-to the forward diffusion process and the `strength` parameter. A `stregnth` of
+to the forward diffusion process and the `strength` parameter. A `strength` of
 0.0 means no noise and a `strength` of 1.0 means starting from completely
 random noise.
 
@@ -78,6 +78,7 @@ The command to generate the above images is:
 
     python image2image.py --strength 0.5 original.png 'A lit fireplace'
 
+*Note: `image2image.py` will automatically downsample your input image to guarantee that its dimensions are divisible by 64. If you want full control of this process, resize your image prior to using the script.*
 
 Performance
 -----------

--- a/stable_diffusion/image2image.py
+++ b/stable_diffusion/image2image.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
 
     sd = StableDiffusion()
 
-    # Read the image    
+    # Read the image
     img = Image.open(args.image)
 
     # Make sure image shape is divisible by 64

--- a/stable_diffusion/image2image.py
+++ b/stable_diffusion/image2image.py
@@ -27,8 +27,16 @@ if __name__ == "__main__":
 
     sd = StableDiffusion()
 
-    # Read the image
-    img = mx.array(np.array(Image.open(args.image)))
+    # Read the image    
+    img = Image.open(args.image)
+
+    # Make sure image shape is divisible by 64
+    W, H = (dim - dim % 64 for dim in (img.width, img.height))
+    if W != img.width or H != img.height:
+        print(f"Warning: image shape is not divisible by 64, downsampling to {W}x{H}")
+        img = img.resize((W, H), Image.NEAREST)  # use desired downsampling filter
+
+    img = mx.array(np.array(img))
     img = (img[:, :, :3].astype(mx.float32) / 255) * 2 - 1
 
     # Noise and denoise the latents produced by encoding img.

--- a/stable_diffusion/stable_diffusion/__init__.py
+++ b/stable_diffusion/stable_diffusion/__init__.py
@@ -30,6 +30,16 @@ def _repeat(x, n, axis):
 
     return x.reshape(s)
 
+def _downsample_nearest(x, target_width, target_height):
+    H, W, _ = x.shape
+
+    idx_height = mx.floor(mx.linspace(0, H - 1, target_height)).astype(mx.int32)
+    idx_width = mx.floor(mx.linspace(0, W - 1, target_width)).astype(mx.int32)
+
+    # Index the image, skipping pixels to match target size
+    downsampled = x[idx_height[:, None], idx_width, :]
+
+    return downsampled
 
 class StableDiffusion:
     def __init__(self, model: str = _DEFAULT_MODEL, float16: bool = False):
@@ -141,6 +151,10 @@ class StableDiffusion:
         conditioning = self._get_text_conditioning(
             text, n_images, cfg_weight, negative_text
         )
+
+        # Make sure image shape is divisible by 64
+        W, H = (dim - dim % 64 for dim in (image.shape[0], image.shape[1]))
+        image = _downsample_nearest(image, W, H)
 
         # Get the latents from the input image and add noise according to the
         # start time.

--- a/stable_diffusion/stable_diffusion/__init__.py
+++ b/stable_diffusion/stable_diffusion/__init__.py
@@ -30,17 +30,6 @@ def _repeat(x, n, axis):
 
     return x.reshape(s)
 
-def _downsample_nearest(x, target_width, target_height):
-    H, W, _ = x.shape
-
-    idx_height = mx.floor(mx.linspace(0, H - 1, target_height)).astype(mx.int32)
-    idx_width = mx.floor(mx.linspace(0, W - 1, target_width)).astype(mx.int32)
-
-    # Index the image, skipping pixels to match target size
-    downsampled = x[idx_height[:, None], idx_width, :]
-
-    return downsampled
-
 class StableDiffusion:
     def __init__(self, model: str = _DEFAULT_MODEL, float16: bool = False):
         self.dtype = mx.float16 if float16 else mx.float32
@@ -151,12 +140,6 @@ class StableDiffusion:
         conditioning = self._get_text_conditioning(
             text, n_images, cfg_weight, negative_text
         )
-
-        # Make sure image shape is divisible by 64
-        W, H = (dim - dim % 64 for dim in (image.shape[0], image.shape[1]))
-        if W != image.shape[0] or H != image.shape[1]:
-            print(f"Warning: image shape is not divisible by 64, downsampling to {W}x{H}")
-            image = _downsample_nearest(image, W, H)
 
         # Get the latents from the input image and add noise according to the
         # start time.

--- a/stable_diffusion/stable_diffusion/__init__.py
+++ b/stable_diffusion/stable_diffusion/__init__.py
@@ -154,7 +154,9 @@ class StableDiffusion:
 
         # Make sure image shape is divisible by 64
         W, H = (dim - dim % 64 for dim in (image.shape[0], image.shape[1]))
-        image = _downsample_nearest(image, W, H)
+        if W != image.shape[0] or H != image.shape[1]:
+            print(f"Warning: image shape is not divisible by 64, downsampling to {W}x{H}")
+            image = _downsample_nearest(image, W, H)
 
         # Get the latents from the input image and add noise according to the
         # start time.

--- a/stable_diffusion/stable_diffusion/__init__.py
+++ b/stable_diffusion/stable_diffusion/__init__.py
@@ -30,6 +30,7 @@ def _repeat(x, n, axis):
 
     return x.reshape(s)
 
+
 class StableDiffusion:
     def __init__(self, model: str = _DEFAULT_MODEL, float16: bool = False):
         self.dtype = mx.float16 if float16 else mx.float32

--- a/whisper/whisper/load_models.py
+++ b/whisper/whisper/load_models.py
@@ -5,9 +5,8 @@ from pathlib import Path
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx.utils import tree_unflatten
-
 from huggingface_hub import snapshot_download
+from mlx.utils import tree_unflatten
 
 from . import whisper
 
@@ -18,11 +17,7 @@ def load_model(
 ) -> whisper.Whisper:
     model_path = Path(path_or_hf_repo)
     if not model_path.exists():
-        model_path = Path(
-            snapshot_download(
-                repo_id=path_or_hf_repo
-            )
-        )
+        model_path = Path(snapshot_download(repo_id=path_or_hf_repo))
 
     with open(str(model_path / "config.json"), "r") as f:
         config = json.loads(f.read())


### PR DESCRIPTION
closes #267 

U-Net requires that it's input is evenly divisible by the number of down / up blocks used as to guarantee that the skip connections can be added properly (avoiding shape mismatch). This is a well documented limitation [1](https://stackoverflow.com/questions/66028743/how-to-handle-odd-resolutions-in-unet-architecture-pytorch) [2](https://github.com/CompVis/stable-diffusion/issues/268) [3](https://github.com/CompVis/stable-diffusion/issues/191) of both UNet and SD. 

One solution is to just throw an error and let the user resize their input, another is to resize it for them. I followed the reasoning in [HuggingFace diffusers](https://github.com/huggingface/diffusers/blob/3be7c96e28495d2e45af5a5f8488a9bb41d66ccb/src/diffusers/image_processor.py#L787) which downsamples the input image using nearest neighbor interpolation. I wrote the downsampling function myself as I was uncertain if we wanted to include external libraries. Given that Stable Diffusion already uses Pillow one alternative is to use Pillow's own resize. This would also give the user more options when it comes to what kind of interpolation algorithm they want to use.  

Running SD on my own computer is very slow, I've made sure that the downsampling works but if someone could confirm SD output that would be great.

