### PR TITLE
Fix Tokenizer save error.

### DIFF
--- a/lora/fuse.py
+++ b/lora/fuse.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
 
     model.update_modules(tree_unflatten(fused_linears))
     weights = dict(tree_flatten(model.parameters()))
-    utils.save_model(args.save_path, weights, tokenizer._tokenizer, config)
+    utils.save_model(args.save_path, weights, tokenizer, config)
 
     if args.upload_name is not None:
         hf_path = args.hf_path


### PR DESCRIPTION
Currently when one runs `python fuse.py` (assuming you have a `mlx_model` folder and a `adapters.npz` file.
It throws an error:

```
AttributeError: 'tokenizers.Tokenizer' object has no attribute 'save_pretrained'. Did you mean: 'from_pretrained'?
```

This PR fixes that.