### PR TITLE
Fix use of undefiend args variable inside generate function in hf_llm example

### DIFF
--- a/llms/hf_llm/generate.py
+++ b/llms/hf_llm/generate.py
@@ -28,8 +28,8 @@ def generate(
     tokens = []
     skip = 0
     for token, n in zip(
-        models.generate(prompt, model, args.temp),
-        range(args.max_tokens),
+        models.generate(prompt, model, temp),
+        range(max_tokens),
     ):
         if token == tokenizer.eos_token_id:
             break


### PR DESCRIPTION
Similar to the one in [this PR](https://github.com/ml-explore/mlx-examples/pull/265).
The `generate` function uses `args` defined in the main function instead of using its function parameters.