### PR TITLE
prompt parameter

### DIFF
--- a/lora/lora.py
+++ b/lora/lora.py
@@ -263,9 +263,9 @@ def train(model, train_set, val_set, optimizer, loss, tokenizer, args):
 
 
 def generate(model, prompt, tokenizer, args):
-    print(args.prompt, end="", flush=True)
+    print(prompt, end="", flush=True)
 
-    prompt = mx.array(tokenizer.encode(args.prompt))
+    prompt = mx.array(tokenizer.encode(prompt))
 
     tokens = []
     skip = 0


### PR DESCRIPTION
The prompt parameter was unused in the generate function. The function should use the passed in parameter instead of accessing `args.prompt` directly.