### PR TITLE
Fix TypeError in whisper benchmark script

### DIFF
--- a/whisper/benchmark.py
+++ b/whisper/benchmark.py
@@ -66,7 +66,7 @@ def decode(model, mels):
 
 
 def everything(model_path):
-    return transcribe(audio_file, model_path=model_path)
+    return transcribe(audio_file, path_or_hf_repo=model_path)
 
 
 if __name__ == "__main__":

--- a/whisper/benchmark.py
+++ b/whisper/benchmark.py
@@ -128,7 +128,7 @@ if __name__ == "__main__":
             ],
             mx.int32,
         )[None]
-        model = load_models.load_model(model_path, dtype=mx.float16)
+        model = load_models.load_model(path_or_hf_repo=model_path, dtype=mx.float16)
         mels = feats(model.dims.n_mels)[None].astype(mx.float16)
         model_forward_time = timer(model_forward, model, mels, tokens)
         print(f"Model forward time {model_forward_time:.3f}")

--- a/whisper/whisper/decoding.py
+++ b/whisper/whisper/decoding.py
@@ -115,6 +115,9 @@ class DecodingOptions:
     # implementation details
     fp16: bool = True  # use fp16 for most of the calculation
 
+    # local path to the model weights
+    model_path: Optional[str] = None
+
 
 @dataclass(frozen=True)
 class DecodingResult:

--- a/whisper/whisper/decoding.py
+++ b/whisper/whisper/decoding.py
@@ -115,9 +115,6 @@ class DecodingOptions:
     # implementation details
     fp16: bool = True  # use fp16 for most of the calculation
 
-    # local path to the model weights
-    model_path: Optional[str] = None
-
 
 @dataclass(frozen=True)
 class DecodingResult:


### PR DESCRIPTION
Executing `python benchmark.py` from the `whisper` directory yields
```tb
TypeError: DecodingOptions.__init__() got an unexpected keyword argument 'model_path'
```

This PR aims at fixing the issue by adding the appropriate placeholder for `model_path` in the `DecodingOptions` dataclass.