### PR TITLE
fix mlx_lm generator for chinese

### DIFF
--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -130,10 +130,11 @@ def generate(
 
         if verbose:
             s = tokenizer.decode(tokens)
-            print(s[skip:], end="", flush=True)
-            skip = len(s)
+            if '�' not in s:
+                print(s[skip:], end="", flush=True)
+                skip = len(s)
 
-    tokens = tokenizer.decode(tokens)[skip:]
+    tokens = tokenizer.decode(tokens)[skip:].replace('�', '')
     if verbose:
         print(tokens, flush=True)
     return tokens


### PR DESCRIPTION
Some Chinese characters require more than two or three tokens to decode, in the verbose version, tokens will be decoded immediately, rather than wait for two or three tokens.

code
```python
response = generate(model, tokenizer, prompt='''[INST] 写100个中文生僻字 [/INST] ''', verbose=True, max_tokens=100)
``` 
output
> 以下是100个中文生��字（古文字），它们在现代汉语中仍然被使用，但它们的形式与现代字形不同：
> 
> 1. ��：一
> 2. ��：二
> 3. ��：三
> 4. ��：四
> 5. ��：五
> 6. ��

fixed output
> 以下是100个中文生僻字（古文字），它们在现代汉语中仍然被使用，但它们的形式与现代字形不同：
> 
> 1. 幺：一
> 2. 乙：二
> 3. 丈：三
> 4. 乗：四
> 5. 乙：五
> 6. 
