### PR TITLE
Update image2image.py

### DIFF
--- a/stable_diffusion/image2image.py
+++ b/stable_diffusion/image2image.py
@@ -69,5 +69,5 @@ if __name__ == "__main__":
     x = (x * 255).astype(mx.uint8)
 
     # Save them to disc
-    im = Image.fromarray(x.__array__())
+    im = Image.fromarray(np.array(x))
     im.save(args.output)


### PR DESCRIPTION
To fix the program fails with:
~/repo/mlx-examples/stable_diffusion/image2image.py", line 72, in <module>
    im = Image.fromarray(x.__array__())
                         ^^^^^^^^^^^
AttributeError: 'mlx.core.array' object has no attribute '__array__'