### PR TITLE
add an option to apply the tokenizer chat template

### DIFF
--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -64,15 +64,14 @@ def main(args):
 
     model, tokenizer = load(args.model, tokenizer_config=tokenizer_config)
 
-    if not args.ignore_chat_template:
+    if not args.ignore_chat_template and (
+        hasattr(tokenizer, "apply_chat_template")
+        and tokenizer.chat_template is not None
+    ):
         messages = [{"role": "user", "content": args.prompt}]
-        if (
-            hasattr(tokenizer, "apply_chat_template")
-            and tokenizer.chat_template is not None
-        ):
-            prompt = tokenizer.apply_chat_template(
-                messages, tokenize=False, add_generation_prompt=True
-            )
+        prompt = tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
     else:
         prompt = args.prompt
 

--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -46,6 +46,12 @@ def setup_arg_parser():
         "--temp", type=float, default=DEFAULT_TEMP, help="Sampling temperature"
     )
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="PRNG seed")
+    parser.add_argument(
+        "--apply_chat_template",
+        "-a",
+        action="store_true",
+        help="apply the tokenizer's chat template on the prompt",
+    )
     return parser
 
 
@@ -58,9 +64,21 @@ def main(args):
         tokenizer_config["eos_token"] = args.eos_token
 
     model, tokenizer = load(args.model, tokenizer_config=tokenizer_config)
+
+    if args.apply_chat_template:
+        messages = [{"role": "user", "content": args.prompt}]
+        # test if the tokenizer has a chat template
+        if not hasattr(tokenizer, "apply_chat_template"):
+            raise ValueError(f"{args.model} does not have a chat template")
+        prompt = tokenizer.apply_chat_template(
+            messages, tokenize=False, add_special_tokens=False
+        )
+    else:
+        prompt = args.prompt
+
     print("=" * 10)
-    print("Prompt:", args.prompt)
-    prompt = tokenizer.encode(args.prompt)
+    print("Prompt:", prompt)
+    prompt = tokenizer.encode(prompt)
     prompt = mx.array(prompt)
     tic = time.time()
     tokens = []

--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -47,10 +47,9 @@ def setup_arg_parser():
     )
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="PRNG seed")
     parser.add_argument(
-        "--apply_chat_template",
-        "-a",
+        "--ignore-chat-template",
         action="store_true",
-        help="apply the tokenizer's chat template on the prompt",
+        help="don't apply the tokenizer chat template on the prompt",
     )
     return parser
 
@@ -65,19 +64,15 @@ def main(args):
 
     model, tokenizer = load(args.model, tokenizer_config=tokenizer_config)
 
-    if args.apply_chat_template:
+    if not args.ignore_chat_template:
         messages = [{"role": "user", "content": args.prompt}]
-        if not hasattr(tokenizer, "apply_chat_template"):
-            raise ValueError(
-                "apply_chat_template() method does not exist, please update your transformers library"
+        if (
+            hasattr(tokenizer, "apply_chat_template")
+            and tokenizer.chat_template is not None
+        ):
+            prompt = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
             )
-        if tokenizer.chat_template is None:
-            print(
-                f"{args.model} does not define a chat template, using the default template, which may cause unexpected results"
-            )
-        prompt = tokenizer.apply_chat_template(
-            messages, tokenize=False, add_generation_prompt=True
-        )
     else:
         prompt = args.prompt
 

--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -49,7 +49,7 @@ def setup_arg_parser():
     parser.add_argument(
         "--ignore-chat-template",
         action="store_true",
-        help="don't apply the tokenizer chat template on the prompt",
+        help="Use the raw prompt without the tokenizer's chat template.",
     )
     return parser
 

--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -67,9 +67,14 @@ def main(args):
 
     if args.apply_chat_template:
         messages = [{"role": "user", "content": args.prompt}]
-        # test if the tokenizer has a chat template
         if not hasattr(tokenizer, "apply_chat_template"):
-            raise ValueError(f"{args.model} does not have a chat template")
+            raise ValueError(
+                "apply_chat_template() method does not exist, please update your transformers library"
+            )
+        if tokenizer.chat_template is None:
+            print(
+                f"{args.model} does not define a chat template, using the default template, which may cause unexpected results"
+            )
         prompt = tokenizer.apply_chat_template(
             messages, tokenize=False, add_generation_prompt=True
         )

--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -71,7 +71,7 @@ def main(args):
         if not hasattr(tokenizer, "apply_chat_template"):
             raise ValueError(f"{args.model} does not have a chat template")
         prompt = tokenizer.apply_chat_template(
-            messages, tokenize=False, add_special_tokens=False
+            messages, tokenize=False, add_generation_prompt=True
         )
     else:
         prompt = args.prompt


### PR DESCRIPTION
Hi,
here is a small tweak to mlx_lm to be able to apply the defined chat_template (in tokenizer_config.json) when using it to quickly and correctly generate in cli.

I love your work, 😍
