### PR TITLE
feat(lora): add de-quantized support for fuse.py

### DIFF
--- a/lora/fuse.py
+++ b/lora/fuse.py
@@ -4,6 +4,7 @@ import argparse
 from pathlib import Path
 
 import mlx.core as mx
+import mlx.nn as nn
 import utils
 from mlx.utils import tree_flatten, tree_unflatten
 from models.lora import LoRALinear
@@ -41,6 +42,12 @@ if __name__ == "__main__":
         type=str,
         default=None,
     )
+    parser.add_argument(
+        "-d",
+        "--de-quantize",
+        help="Generate a de-quantized model.",
+        action="store_true",
+    )
 
     print("Loading pretrained model")
     args = parser.parse_args()
@@ -53,7 +60,7 @@ if __name__ == "__main__":
 
     # Freeze all layers other than LORA linears
     model.freeze()
-    for l in model.model.layers[-lora_layers:]:
+    for l in model.model.layers[len(model.model.layers) - lora_layers :]:
         l.self_attn.q_proj = LoRALinear.from_linear(l.self_attn.q_proj)
         l.self_attn.v_proj = LoRALinear.from_linear(l.self_attn.v_proj)
         if hasattr(l, "block_sparse_moe"):
@@ -67,8 +74,33 @@ if __name__ == "__main__":
     ]
 
     model.update_modules(tree_unflatten(fused_linears))
+
+    if args.de_quantize:
+        de_quantize_layers = []
+        for n, m in model.named_modules():
+            if isinstance(m, nn.QuantizedLinear):
+                bias = "bias" in m
+                weight = m.weight
+                weight = mx.dequantize(
+                    weight,
+                    m.scales,
+                    m.biases,
+                    m.group_size,
+                    m.bits,
+                ).astype(mx.float16)
+                output_dims, input_dims = weight.shape
+                linear = nn.Linear(input_dims, output_dims, bias=bias)
+                linear.weight = weight
+                if bias:
+                    linear.bias = m.bias
+                de_quantize_layers.append((n, linear))
+
+        model.update_modules(tree_unflatten(de_quantize_layers))
+
     weights = dict(tree_flatten(model.parameters()))
-    utils.save_model(args.save_path, weights, tokenizer, config)
+    utils.save_model(
+        args.save_path, weights, tokenizer, config, de_quantize=args.de_quantize
+    )
 
     if args.upload_name is not None:
         hf_path = args.hf_path

--- a/lora/fuse.py
+++ b/lora/fuse.py
@@ -98,9 +98,9 @@ if __name__ == "__main__":
         model.update_modules(tree_unflatten(de_quantize_layers))
 
     weights = dict(tree_flatten(model.parameters()))
-    utils.save_model(
-        args.save_path, weights, tokenizer, config, de_quantize=args.de_quantize
-    )
+    if args.de_quantize:
+        config.pop("quantization", None)
+    utils.save_model(args.save_path, weights, tokenizer, config)
 
     if args.upload_name is not None:
         hf_path = args.hf_path

--- a/lora/models/lora.py
+++ b/lora/models/lora.py
@@ -16,7 +16,7 @@ class LoRALinear(nn.Module):
         lora_lin.linear = linear
         return lora_lin
 
-    def to_linear(self):
+    def to_linear(self, de_quantize: bool = False):
         linear = self.linear
         bias = "bias" in linear
         weight = linear.weight
@@ -43,7 +43,7 @@ class LoRALinear(nn.Module):
         if bias:
             fused_linear.bias = linear.bias
 
-        if is_quantized:
+        if is_quantized and not de_quantize:
             fused_linear = nn.QuantizedLinear.from_linear(
                 fused_linear,
                 linear.group_size,

--- a/lora/utils.py
+++ b/lora/utils.py
@@ -112,7 +112,7 @@ def make_shards(weights: dict, max_file_size_gibibyte: int = 15):
     return shards
 
 
-def save_model(save_dir: str, weights, tokenizer, config, de_quantize: bool = False):
+def save_model(save_dir: str, weights, tokenizer, config):
     save_dir = Path(save_dir)
     save_dir.mkdir(parents=True, exist_ok=True)
 
@@ -131,8 +131,6 @@ def save_model(save_dir: str, weights, tokenizer, config, de_quantize: bool = Fa
     tokenizer.save_pretrained(save_dir)
 
     with open(save_dir / "config.json", "w") as fid:
-        if de_quantize:
-            config.pop("quantization", None)
         json.dump(config, fid, indent=4)
 
 


### PR DESCRIPTION
Quick and dirty implementation for supporting de-quant model during fusing. Also, updated the model weight to use HF format so that once the model is fused, it can be converted by gguf for more advanced quant support. 

PS: Once the Lora example is merged into mlx-lm, we can properly add this functionality and make the fused model can be directly loaded by the transformers library to support AWQ/GPTQ.