### PR TITLE
chore(mlx-lm): bump the mlx-lm python version requirement

### DIFF
--- a/llms/setup.py
+++ b/llms/setup.py
@@ -19,5 +19,5 @@ setup(
     license="MIT",
     install_requires=requirements,
     packages=["mlx_lm", "mlx_lm.models"],
-    python_requires=">=3.8",
+    python_requires=">=3.10",
 )


### PR DESCRIPTION
To avoid the error https://github.com/ml-explore/mlx-examples/issues/348 after merging the lora example into mlx-lm.