### PR TITLE
fix qwen mlp w2

### DIFF
--- a/llms/qwen/qwen.py
+++ b/llms/qwen/qwen.py
@@ -95,7 +95,7 @@ class MLP(nn.Module):
             args.hidden_size, args.intermediate_size // 2, bias=not args.no_bias
         )
         self.w2 = nn.Linear(
-            args.intermediate_size // 2, args.hidden_size, bias=not args.no_bias
+            args.hidden_size, args.intermediate_size // 2, bias=not args.no_bias
         )
         self.c_proj = nn.Linear(
             args.intermediate_size // 2, args.hidden_size, bias=not args.no_bias


### PR DESCRIPTION
The dimensions of the input and output of `w2` in Qwen MLP are incorrect. The correct implementation is as follows:

https://huggingface.co/Qwen/Qwen-1_8B/blob/fa6e214ccbbc6a55235c26ef406355b6bfdf5eed/modeling_qwen.py#L564

```python
class QWenMLP(nn.Module):
    def __init__(self, config):
        super().__init__()
        self.w1 = nn.Linear(
            config.hidden_size, config.intermediate_size // 2, bias=not config.no_bias
        )
        self.w2 = nn.Linear(
            config.hidden_size, config.intermediate_size // 2, bias=not config.no_bias
        )
        ff_dim_in = config.intermediate_size // 2
        self.c_proj = nn.Linear(ff_dim_in, config.hidden_size, bias=not config.no_bias)
```

**Why is the current `qwen.py` functioning properly?**

According to my debugging results, after executing this line, the dimensions of `w2` are restored correctly to `(config.hidden_size, config.intermediate_size // 2)`.

```python
weights = mx.load(str(model_path / "weights.npz"))
```