### PR TITLE
Uplaod train loss data to wandb

### DIFF
--- a/lora/README.md
+++ b/lora/README.md
@@ -93,6 +93,8 @@ the output location with `--adapter-file`.
 You can resume fine-tuning with an existing adapter with `--resume-adapter-file
 <path_to_adapters.npz>`. 
 
+You can use `--wandb-log` to upload the training loss data to the [wandb](https://wandb.ai/site) platform.
+
 ### Evaluate
 
 To compute test set perplexity use:

--- a/lora/lora.py
+++ b/lora/lora.py
@@ -352,10 +352,12 @@ if __name__ == "__main__":
         if hasattr(l, "block_sparse_moe"):
             l.block_sparse_moe.gate = LoRALinear.from_linear(l.block_sparse_moe.gate)
 
-    p = sum(v.size for _, v in tree_flatten(model.parameters())) / 10**6
-    print(f"Total parameters {p:.3f}M")
-    p = sum(v.size for _, v in tree_flatten(model.trainable_parameters())) / 10**6
-    print(f"Trainable parameters {p:.3f}M")
+    total_p = sum(v.size for _, v in tree_flatten(model.parameters())) / 10 ** 6
+    print(f"Total parameters {total_p:.3f}M")
+    train_p = sum(v.size for _, v in tree_flatten(model.trainable_parameters())) / 10 ** 6
+    print(f"Trainable parameters {train_p:.3f}M")
+    p = 100 * train_p / total_p
+    print(f"Trainable percentage {p:.3f}%")
 
     print("Loading datasets")
     train_set, valid_set, test_set = load(args)


### PR DESCRIPTION
Use it as follows:

```
python lora.py --model <path_to_model> \
               --train \
               --wandb-log \
               --iters 600
``` 

When I use it, the training data generated on the wandb platform is as follows

<img width="1032" alt="image" src="https://github.com/ml-explore/mlx-examples/assets/6247142/452c682a-391a-4efa-808f-555417bc4776">


