### PR TITLE
chore(mlx-lm): truncate the input sentence to max seq len in lora iterate_batches

### DIFF
--- a/llms/mlx_lm/tuner/trainer.py
+++ b/llms/mlx_lm/tuner/trainer.py
@@ -175,6 +175,7 @@ def train(
                 tokenizer=tokenizer,
                 batch_size=args.batch_size,
                 num_batches=args.val_batches,
+                max_seq_length=args.max_seq_length,
             )
             print(
                 f"Iter {it + 1}: "

--- a/llms/mlx_lm/tuner/trainer.py
+++ b/llms/mlx_lm/tuner/trainer.py
@@ -60,7 +60,7 @@ def iterate_batches(dataset, tokenizer, batch_size, max_seq_length, train=False)
         indices = np.random.permutation(indices)
         # Collect batches from dataset
         for i in range(0, len(indices) - batch_size + 1, batch_size):
-            # Encode batch
+            # Encode batch up to the max seq length
             batch = [
                 tokenizer.encode(dataset[indices[i + j]])[:max_seq_length]
                 for j in range(batch_size)

--- a/llms/mlx_lm/tuner/trainer.py
+++ b/llms/mlx_lm/tuner/trainer.py
@@ -62,23 +62,19 @@ def iterate_batches(dataset, tokenizer, batch_size, max_seq_length, train=False)
         for i in range(0, len(indices) - batch_size + 1, batch_size):
             # Encode batch
             batch = [
-                tokenizer.encode(dataset[indices[i + j]]) for j in range(batch_size)
+                tokenizer.encode(dataset[indices[i + j]])[:max_seq_length]
+                for j in range(batch_size)
             ]
             lengths = [len(x) for x in batch]
 
-            # Check if any sequence is longer than max_seq_length
-            if max(lengths) > max_seq_length:
-                print(
-                    "[WARNING] Some sequences are longer than 2048 tokens. "
-                    "Consider pre-splitting your data to save memory."
-                )
-
             # Pad to the max length
-            batch_arr = np.zeros((batch_size, max(lengths)), np.int32)
+            max_length_in_batch = min(max(lengths), max_seq_length)
+            batch_arr = np.zeros((batch_size, max_length_in_batch), np.int32)
 
             for j in range(batch_size):
                 batch_arr[j, : lengths[j]] = batch[j]
             batch = mx.array(batch_arr)
+
             yield batch[:, :-1], batch[:, 1:], mx.array(lengths)
 
         if not train:


### PR DESCRIPTION
The current iterate_batches function will return a batch with the maximum length that the training set sentence has. This can cause a memory spike when the training dataset contains long sentences, which may crash the training process.