### PR TITLE
chore(mlx-lm): add reset lora layers helper

### DIFF
--- a/llms/mlx_lm/tuner/utils.py
+++ b/llms/mlx_lm/tuner/utils.py
@@ -77,7 +77,7 @@ def remove_lora_layers(model: nn.Module) -> nn.Module:
         model (nn.Module): The model with LoRA layers.
 
     Returns:
-        nn.Module: The model with reset LoRA layers.
+        nn.Module: The model without LoRA layers.
     """
     reset_layers = []
     for name, module in model.named_modules():

--- a/llms/mlx_lm/tuner/utils.py
+++ b/llms/mlx_lm/tuner/utils.py
@@ -69,7 +69,7 @@ def dequantize(model: nn.Module) -> nn.Module:
     return model
 
 
-def reset_lora_layers(model: nn.Module) -> nn.Module:
+def remove_lora_layers(model: nn.Module) -> nn.Module:
     """
     Reset the LoRA layers to original linear layers in the model.
 

--- a/llms/mlx_lm/tuner/utils.py
+++ b/llms/mlx_lm/tuner/utils.py
@@ -47,23 +47,42 @@ def dequantize(model: nn.Module) -> nn.Module:
         nn.Module: The model with dequantized layers.
     """
     de_quantize_layers = []
-    for n, m in model.named_modules():
-        if isinstance(m, nn.QuantizedLinear):
-            bias = "bias" in m
-            weight = m.weight
+    for name, module in model.named_modules():
+        if isinstance(module, nn.QuantizedLinear):
+            bias = "bias" in module
+            weight = module.weight
             weight = mx.dequantize(
                 weight,
-                m.scales,
-                m.biases,
-                m.group_size,
-                m.bits,
+                module.scales,
+                module.biases,
+                module.group_size,
+                module.bits,
             ).astype(mx.float16)
             output_dims, input_dims = weight.shape
             linear = nn.Linear(input_dims, output_dims, bias=bias)
             linear.weight = weight
             if bias:
-                linear.bias = m.bias
-            de_quantize_layers.append((n, linear))
+                linear.bias = module.bias
+            de_quantize_layers.append((name, linear))
     if len(de_quantize_layers) > 0:
         model.update_modules(tree_unflatten(de_quantize_layers))
+    return model
+
+
+def reset_lora_layers(model: nn.Module) -> nn.Module:
+    """
+    Reset the LoRA layers to original linear layers in the model.
+
+    Args:
+        model (nn.Module): The model with LoRA layers.
+
+    Returns:
+        nn.Module: The model with reset LoRA layers.
+    """
+    reset_layers = []
+    for name, module in model.named_modules():
+        if isinstance(module, LoRALinear):
+            reset_layers.append((name, module.linear))
+    if len(reset_layers) > 0:
+        model.update_modules(tree_unflatten(reset_layers))
     return model

--- a/llms/mlx_lm/tuner/utils.py
+++ b/llms/mlx_lm/tuner/utils.py
@@ -71,7 +71,7 @@ def dequantize(model: nn.Module) -> nn.Module:
 
 def remove_lora_layers(model: nn.Module) -> nn.Module:
     """
-    Reset the LoRA layers to original linear layers in the model.
+    Remove the LoRA layers from the model.
 
     Args:
         model (nn.Module): The model with LoRA layers.


### PR DESCRIPTION
Add this helper so that we can restore the Lora layers to their original linear layers. This will allow us to switch between Lora layers without having to reload the entire model.

For example:

```python
from mlx_lm import load, generate
from mlx_lm.tuner.utils import apply_lora_layers, reset_lora_layers

model, tokenizer = load("mistralai/Mistral-7B-v0.1", adapter_file="adapter_1.npz")

response = generate(model, tokenizer, prompt="hello", verbose=True)

model = reset_lora_layers(model)
model = apply_lora_layers(model, adapter_file="adapter_2.npz")

response = generate(model, tokenizer, prompt="hello", verbose=True)
```

Given the current mlx loading speed is not optimal, this can be useful for applications that want to change adapters to fit different use cases.