### PR TITLE
Use better time for measuring tokens/second 🚀 

### DIFF
--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -149,7 +149,7 @@ def generate(
 
     prompt = mx.array(tokenizer.encode(prompt))
 
-    tic = time.time()
+    tic = time.perf_counter()
     tokens = []
     skip = 0
     REPLACEMENT_CHAR = "\ufffd"
@@ -158,8 +158,8 @@ def generate(
         if token == tokenizer.eos_token_id:
             break
         if n == 0:
-            prompt_time = time.time() - tic
-            tic = time.time()
+            prompt_time = time.perf_counter() - tic
+            tic = time.perf_counter()
         tokens.append(token.item())
 
         if verbose:
@@ -175,7 +175,7 @@ def generate(
 
     if verbose:
         print(tokens[skip:], flush=True)
-        gen_time = time.time() - tic
+        gen_time = time.perf_counter() - tic
         print("=" * 10)
         if len(tokens) == 0:
             print("No tokens generated for this prompt")


### PR DESCRIPTION
I purpose to change all usage of `time.time()` to [`time.perf_counter()`](https://docs.python.org/3/library/time.html#time.perf_counter) in `utils.py` for MLX-LM

`time.perf_counter` is more preferable when measuring and benchmarking since it is monotonic and higher precision clock compared to `time.time()`

Rough benchmarks with StableLM-2-Zephyr 1.6B model with this change

with time.time()
Prompt: 44.321 tokens-per-sec
Generation: 113.937 tokens-per-sec

with time.perf_counter()
Prompt: 192.664 tokens-per-sec
Generation: 117.253 tokens-per-sec

~~+300% on tokens/s for prompt~~ <- My bad 
+3% for tokens/s for generate