### PR TITLE
StableLM 3B and Stable-code-3b Model Support

### DIFF
--- a/llms/mlx_lm/models/stablelm_epoch.py
+++ b/llms/mlx_lm/models/stablelm_epoch.py
@@ -20,7 +20,6 @@ class ModelArgs(BaseModelArgs):
     intermediate_size: int
     norm_eps: float
     rope_theta: float
-    use_qkv_bias: bool
 
 
 class LayerNorm(nn.LayerNorm):
@@ -45,19 +44,20 @@ class Attention(nn.Module):
                 f"hidden_size must be divisible by num_heads (got `hidden_size`: {self.hidden_size}"
                 f" and `num_heads`: {self.num_heads})."
             )
+        self.use_qkv_bias = True if config.vocab_size > 50304 else False
 
         self.q_proj = nn.Linear(
-            self.hidden_size, self.num_heads * self.head_dim, bias=config.use_qkv_bias
+            self.hidden_size, self.num_heads * self.head_dim, bias=self.use_qkv_bias
         )
         self.k_proj = nn.Linear(
             self.hidden_size,
             self.num_key_value_heads * self.head_dim,
-            bias=config.use_qkv_bias,
+            bias=self.use_qkv_bias,
         )
         self.v_proj = nn.Linear(
             self.hidden_size,
             self.num_key_value_heads * self.head_dim,
-            bias=config.use_qkv_bias,
+            bias=self.use_qkv_bias,
         )
         self.o_proj = nn.Linear(
             self.num_heads * self.head_dim, self.hidden_size, bias=False

--- a/llms/mlx_lm/models/stablelm_epoch.py
+++ b/llms/mlx_lm/models/stablelm_epoch.py
@@ -20,6 +20,7 @@ class ModelArgs(BaseModelArgs):
     intermediate_size: int
     norm_eps: float
     rope_theta: float
+    use_qkv_bias: bool
 
 
 class LayerNorm(nn.LayerNorm):
@@ -44,20 +45,20 @@ class Attention(nn.Module):
                 f"hidden_size must be divisible by num_heads (got `hidden_size`: {self.hidden_size}"
                 f" and `num_heads`: {self.num_heads})."
             )
-        self.use_qkv_bias = True if config.vocab_size > 50304 else False
+        # self.use_qkv_bias = True if config.vocab_size > 50304 else False
 
         self.q_proj = nn.Linear(
-            self.hidden_size, self.num_heads * self.head_dim, bias=self.use_qkv_bias
+            self.hidden_size, self.num_heads * self.head_dim, bias=config.use_qkv_bias
         )
         self.k_proj = nn.Linear(
             self.hidden_size,
             self.num_key_value_heads * self.head_dim,
-            bias=self.use_qkv_bias,
+            bias=config.use_qkv_bias,
         )
         self.v_proj = nn.Linear(
             self.hidden_size,
             self.num_key_value_heads * self.head_dim,
-            bias=self.use_qkv_bias,
+            bias=config.use_qkv_bias,
         )
         self.o_proj = nn.Linear(
             self.num_heads * self.head_dim, self.hidden_size, bias=False


### PR DESCRIPTION
This PR adds support for StableLM 3B and by extension stable-code-3b. 

I am using vocabulary size of the tokenizer to infer the usage of QKV bias.

usage example:

python -m mlx_lm.generate \
--model stabilityai/stable-code-3b \
--max-tokens 500 \
--prompt "Write a quick sort in C++" \
--colorize