### PR TITLE
LoRA: Remove unnecessary model type judgments

### DIFF
--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -12,9 +12,6 @@ from .tuner.lora import LoRALinear
 from .tuner.trainer import TrainingArgs, evaluate, train
 from .utils import generate, load
 
-SUPPORTED_MODELS = [llama.Model, mixtral.Model, phi2.Model]
-
-
 def build_parser():
     parser = argparse.ArgumentParser(description="LoRA or QLoRA finetuning.")
     parser.add_argument(
@@ -165,12 +162,6 @@ if __name__ == "__main__":
 
     print("Loading pretrained model")
     model, tokenizer = load(args.model)
-
-    if model.__class__ not in SUPPORTED_MODELS:
-        raise ValueError(
-            f"Model {model.__class__} not supported. "
-            f"Supported models: { SUPPORTED_MODELS}"
-        )
 
     # Freeze all layers other than LORA linears
     model.freeze()

--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -7,10 +7,9 @@ import mlx.optimizers as optim
 import numpy as np
 from mlx.utils import tree_flatten
 
-from .models import llama, mixtral, phi2
 from .tuner.lora import LoRALinear
 from .tuner.trainer import TrainingArgs, evaluate, train
-from .utils import generate, load
+from .utils import generate, load, LORA_SUPPORTED_MODELS
 
 def build_parser():
     parser = argparse.ArgumentParser(description="LoRA or QLoRA finetuning.")
@@ -162,6 +161,12 @@ if __name__ == "__main__":
 
     print("Loading pretrained model")
     model, tokenizer = load(args.model)
+
+    if model.__class__ not in LORA_SUPPORTED_MODELS:
+        raise ValueError(
+            f"Model {model.__class__} not supported. "
+            f"Supported models: {LORA_SUPPORTED_MODELS}"
+        )
 
     # Freeze all layers other than LORA linears
     model.freeze()

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -25,6 +25,9 @@ MODEL_MAPPING = {
     "qwen": qwen,
     "plamo": plamo,
 }
+LORA_SUPPORTED_MODELS = [
+    llama.Model, mixtral.Model, phi2.Model, stablelm_epoch.Model
+]
 MAX_FILE_SIZE_GB = 5
 
 linear_class_predicate = (


### PR DESCRIPTION
1. Supported models are already checked in the load_model function in utils, no need to repeat the check in lora
2. The checks in lora are not synchronized with those in utils


After deleting this part of the judgment, the Lora module will support the following model fine-tuning:
- stablelm_epoch
- qwen
- plamo

see [MODEL_MAPPING](https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/utils.py#L19-L27) in mlx_lm utils.py .


Also solves issue #356