### PR TITLE
fix token count computation -- produced wrong tps measurements

### DIFF
--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -171,21 +171,22 @@ def generate(
                 print(s[skip:], end="", flush=True)
                 skip = len(s)
 
-    tokens = tokenizer.decode(tokens).replace(REPLACEMENT_CHAR, "")
+    token_count = len(tokens)
+    token_string = tokenizer.decode(tokens).replace(REPLACEMENT_CHAR, "")
 
     if verbose:
-        print(tokens[skip:], flush=True)
+        print(token_string[skip:], flush=True)
         gen_time = time.perf_counter() - tic
         print("=" * 10)
-        if len(tokens) == 0:
+        if token_count == 0:
             print("No tokens generated for this prompt")
             return
         prompt_tps = prompt.size / prompt_time
-        gen_tps = (len(tokens) - 1) / gen_time
+        gen_tps = (token_count - 1) / gen_time
         print(f"Prompt: {prompt_tps:.3f} tokens-per-sec")
         print(f"Generation: {gen_tps:.3f} tokens-per-sec")
 
-    return tokens
+    return token_string
 
 
 def load_model(model_path: Path) -> nn.Module:


### PR DESCRIPTION
PR #342 inadvertently counted the number of characters in the resulting string as the number of tokens.  This inflated the tokens per second count by roughly a factor of 3 (when producing 100 tokens).

Before:

```
python -m mlx_lm.generate --model ~/Mistral-7B-v0.1-hf-4bit-mlx -m 20
==========
Prompt: hello
…

I’ve had my 1366 Samsung 24″ monitor for
==========
Prompt: 15.634 tokens-per-sec
Generation: 60.364 tokens-per-sec
```

After:

```
python -m mlx_lm.generate --model ~/Mistral-7B-v0.1-hf-4bit-mlx -m 20
==========
Prompt: hello
…

I’ve had my 1366 Samsung 24″ monitor for
==========
Prompt: 16.123 tokens-per-sec
Generation: 27.702 tokens-per-sec
```

