### PR TITLE
fix(mlx-lm): apply lora layer doesn't update the lora weights

### DIFF
--- a/llms/mlx_lm/tuner/utils.py
+++ b/llms/mlx_lm/tuner/utils.py
@@ -33,6 +33,9 @@ def apply_lora_layers(model: nn.Module, adapter_file: str) -> nn.Module:
             linear_replacements.append((name, replacement_module))
 
     model.update_modules(tree_unflatten(linear_replacements))
+
+    model.update(tree_unflatten(adapters))
+
     return model
 
 


### PR DESCRIPTION
@awni, I found this while working on the moe model stuff. I noticed that the lora weight doesn't apply to the gate and the weight distribution is almost identical to uniform. So, I dug a bit into the mlx-lm lora code and found out that we only replace the linear layer but never update the lora weight from adapters.