### PR TITLE
Add max sequence length argument in lora.py

### DIFF
--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -113,6 +113,12 @@ def build_parser():
         default=500,
         help="Number of test set batches, -1 uses the entire test set.",
     )
+    parser.add_argument(
+        "--max_seq_length",
+        type=int,
+        default=2048,
+        help="Maximum sequence length.",
+    )
     parser.add_argument("--seed", type=int, default=0, help="The PRNG seed")
     return parser
 
@@ -201,6 +207,7 @@ if __name__ == "__main__":
         steps_per_eval=args.steps_per_eval,
         steps_per_save=args.save_every,
         adapter_file=args.adapter_file,
+        max_seq_length=args.max_seq_length
     )
     if args.train:
         print("Training")


### PR DESCRIPTION
For the issue #407 

A new argument "--max_seq_length" has been added to the command-line parser and passed as a parameter to the main function of the lora.py script. This allows users to specify and control the maximum sequence length during training.

