### PR TITLE
chore(mlx-lm): add model weight index in save_weights

### DIFF
--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -388,7 +388,8 @@ def save_weights(save_path: Union[str, Path], weights: Dict[str, Any]) -> None:
         else "model.safetensors"
     )
 
-    index_data = {"metadata": {"total_size": 0}, "weight_map": {}}
+    total_size = sum(v.nbytes for v in weights.values())
+    index_data = {"metadata": {"total_size": total_size}, "weight_map": {}}
 
     for i, shard in enumerate(shards):
         shard_name = shard_file_format.format(i + 1, shards_count)
@@ -398,8 +399,6 @@ def save_weights(save_path: Union[str, Path], weights: Dict[str, Any]) -> None:
 
         for weight_name in shard.keys():
             index_data["weight_map"][weight_name] = shard_name
-
-        index_data["metadata"]["total_size"] += shard_path.stat().st_size
 
     index_data["weight_map"] = {
         k: index_data["weight_map"][k] for k in sorted(index_data["weight_map"])

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -12,7 +12,6 @@ from huggingface_hub import snapshot_download
 from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizer
 
 # Local imports
-
 from .models import llama, mixtral, olmo, phi2, plamo, qwen, qwen2, stablelm_epoch
 from .tuner.utils import apply_lora_layers
 

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -401,7 +401,7 @@ def save_weights(save_path: Union[str, Path], weights: Dict[str, Any]) -> None:
 
         index_data["metadata"]["total_size"] += shard_path.stat().st_size
 
-    sorted_weight_map = {
+    index_data["weight_map"] = {
         k: index_data["weight_map"][k] for k in sorted(index_data["weight_map"])
     }
 

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -407,7 +407,7 @@ def save_weights(save_path: Union[str, Path], weights: Dict[str, Any]) -> None:
 
     with open(save_path / "model.safetensors.index.json", "w") as f:
         json.dump(
-            {"metadata": index_data["metadata"], "weight_map": sorted_weight_map},
+            index_data,
             f,
             indent=4,
         )


### PR DESCRIPTION
Due to the various different model formats, such as hf/pytorch/custom, it would be beneficial if we had a model weight metadata index. This way, we wouldn't have to download the model weight and check it locally. This approach also aligns with most of the Hugging Face model repository.