### PR TITLE
fix-mistral-download-link

### DIFF
--- a/llms/mistral/README.md
+++ b/llms/mistral/README.md
@@ -16,7 +16,7 @@ pip install -r requirements.txt
 Next, download the model and tokenizer:
 
 ```
-curl -O https://files.mistral-7b-v0-1.mistral.ai/mistral-7B-v0.1.tar
+curl -O https://models.mistralcdn.com/mistral-7b-v0-1/mistral-7B-v0.1.tar
 tar -xf mistral-7B-v0.1.tar
 ```
 


### PR DESCRIPTION
fixing broken link for mistral-7B-v0.1 model

Original change from mistral.ai:

https://github.com/mistralai/mistral-src/commit/8598cf582091a596671be31990448e0620017851