### PR TITLE
Change argument name in lora.py

### DIFF
--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -111,7 +111,7 @@ def build_parser():
         help="Number of test set batches, -1 uses the entire test set.",
     )
     parser.add_argument(
-        "--max_seq_length",
+        "--max-seq-length",
         type=int,
         default=2048,
         help="Maximum sequence length.",


### PR DESCRIPTION
The argument name "--max_seq_length" was updated to "--max-seq-length" in the code to maintain a consistent naming convention across the program.