### PR TITLE
LoRA: Add printing and callbacks for learning rate during training

### DIFF
--- a/llms/mlx_lm/tuner/trainer.py
+++ b/llms/mlx_lm/tuner/trainer.py
@@ -182,11 +182,13 @@ def train(
             train_loss = np.mean(losses)
 
             stop = time.perf_counter()
+            learning_rate = optimizer.learning_rate.item()
             it_sec = args.steps_per_report / (stop - start)
             tokens_sec = float(n_tokens) / (stop - start)
             trained_tokens += n_tokens
             print(
                 f"Iter {it + 1}: Train loss {train_loss:.3f}, "
+                f"Learning Rate {learning_rate:.3e}, "
                 f"It/sec {it_sec:.3f}, "
                 f"Tokens/sec {tokens_sec:.3f}, "
                 f"Trained Tokens {trained_tokens}"
@@ -196,6 +198,7 @@ def train(
                 train_info = {
                     "iteration": it + 1,
                     "train_loss": train_loss,
+                    "learning_rate": learning_rate,
                     "iterations_per_second": it_sec,
                     "tokens_per_second": tokens_sec,
                     "trained_tokens": trained_tokens,

--- a/llms/mlx_lm/tuner/trainer.py
+++ b/llms/mlx_lm/tuner/trainer.py
@@ -121,18 +121,11 @@ def evaluate(
 
 class TrainingCallback:
 
-    def on_train_loss_report(
-        self,
-        steps: int,
-        loss: float,
-        it_sec: float,
-        tokens_sec: float,
-        trained_tokens: int,
-    ):
+    def on_train_loss_report(self, train_info: dict):
         """Called to report training loss at specified intervals."""
         pass
 
-    def on_val_loss_report(self, steps: int, loss: float, val_time: float):
+    def on_val_loss_report(self, val_info: dict):
         """Called to report validation loss at specified intervals or the beginning."""
         pass
 
@@ -146,7 +139,7 @@ def train(
     args: TrainingArgs = TrainingArgs(),
     loss: callable = default_loss,
     iterate_batches: callable = iterate_batches,
-    training_callback=None,
+    training_callback: TrainingCallback = None,
 ):
     print(f"Starting training..., iters: {args.iters}")
 
@@ -200,9 +193,14 @@ def train(
             )
 
             if training_callback is not None:
-                training_callback.on_train_loss_report(
-                    it + 1, train_loss, it_sec, tokens_sec, trained_tokens
-                )
+                train_info = {
+                    "iteration": it + 1,
+                    "train_loss": train_loss,
+                    "iterations_per_second": it_sec,
+                    "tokens_per_second": tokens_sec,
+                    "trained_tokens": trained_tokens,
+                }
+                training_callback.on_train_loss_report(train_info)
 
             losses = []
             n_tokens = 0
@@ -229,7 +227,12 @@ def train(
             )
 
             if training_callback is not None:
-                training_callback.on_val_loss_report(it + 1, val_loss, val_time)
+                val_info = {
+                    "iteration": it + 1,
+                    "val_loss": val_loss,
+                    "val_time": val_time
+                }
+                training_callback.on_val_loss_report(val_info)
 
             start = time.perf_counter()
 


### PR DESCRIPTION
Optimized the TrainingCallback definition to put some information during training into the dict, increasing the flexibility of subsequent extensions. 

Also, the corresponding learning rate information is printed during training. Here's part of the printout from when I was training:

```
Training
Starting training..., iters: 800
Iter 1: Val loss 4.847, Val took 31.577s
Iter 10: Train loss 4.461, Learning Rate 1.000e-05, It/sec 0.608, Tokens/sec 677.748, Trained Tokens 11152,
Iter 20: Train loss 3.146, Learning Rate 1.000e-05, It/sec 0.529, Tokens/sec 594.284, Trained Tokens 22383,
Iter 30: Train loss 2.157, Learning Rate 1.000e-05, It/sec 0.495, Tokens/sec 544.745, Trained Tokens 33387,
Iter 40: Train loss 1.758, Learning Rate 1.000e-05, It/sec 0.472, Tokens/sec 525.752, Trained Tokens 44534,
Iter 50: Train loss 1.471, Learning Rate 1.000e-05, It/sec 0.509, Tokens/sec 565.160, Trained Tokens 55634,
Iter 60: Train loss 1.367, Learning Rate 1.000e-05, It/sec 0.521, Tokens/sec 589.875, Trained Tokens 66965,
Iter 70: Train loss 1.230, Learning Rate 1.000e-05, It/sec 0.505, Tokens/sec 567.251, Trained Tokens 78189,
Iter 80: Train loss 1.191, Learning Rate 1.000e-05, It/sec 0.407, Tokens/sec 460.756, Trained Tokens 89497,
Iter 90: Train loss 1.073, Learning Rate 1.000e-05, It/sec 0.510, Tokens/sec 558.328, Trained Tokens 100445,
Iter 100: Train loss 1.045, Learning Rate 1.000e-05, It/sec 0.484, Tokens/sec 535.360, Trained Tokens 111513,
```

Given that the learning rate schedulers setting is supported in the `mlx` [0.3.0](https://github.com/ml-explore/mlx/releases/tag/v0.3.0) version, I added the `optim.cosine_decay ` policy to try it out, and the output is as follows The output is as follows:

```
Training
Starting training..., iters: 800
Iter 1: Val loss 4.736, Val took 31.531s
Iter 10: Train loss 3.670, Learning Rate 2.999e-05, It/sec 0.614, Tokens/sec 684.757, Trained Tokens 11152
Iter 20: Train loss 1.841, Learning Rate 2.996e-05, It/sec 0.518, Tokens/sec 582.276, Trained Tokens 22383
Iter 30: Train loss 1.308, Learning Rate 2.990e-05, It/sec 0.493, Tokens/sec 542.688, Trained Tokens 33387
Iter 40: Train loss 1.153, Learning Rate 2.982e-05, It/sec 0.483, Tokens/sec 538.068, Trained Tokens 44534
Iter 50: Train loss 1.000, Learning Rate 2.972e-05, It/sec 0.487, Tokens/sec 540.478, Trained Tokens 55634
Iter 60: Train loss 0.991, Learning Rate 2.960e-05, It/sec 0.489, Tokens/sec 554.068, Trained Tokens 66965
Iter 70: Train loss 0.921, Learning Rate 2.945e-05, It/sec 0.441, Tokens/sec 494.752, Trained Tokens 78189
Iter 80: Train loss 0.907, Learning Rate 2.928e-05, It/sec 0.322, Tokens/sec 363.570, Trained Tokens 89497
Iter 90: Train loss 0.828, Learning Rate 2.909e-05, It/sec 0.411, Tokens/sec 449.679, Trained Tokens 100445
Iter 100: Train loss 0.815, Learning Rate 2.888e-05, It/sec 0.411, Tokens/sec 454.525, Trained Tokens 111513
```

The display effect of the learning rates corresponding to the above two sets of training on wandb is roughly as follows:

<img width="785" alt="image" src="https://github.com/ml-explore/mlx-examples/assets/6247142/5827eef2-a52b-4f99-8bb4-51990ae8250c">


In addition, I don't know whether it is appropriate to add `optim.cosine_decay` in the Lora.py script, so I did not submit this part of the content. I can add this part of the content if necessary. Adjustments are as follows:

```diff
+ scheduler = optim.cosine_decay(args.learning_rate, args.iters)
+ opt = optim.AdamW(learning_rate=scheduler)
- opt = optim.AdamW(learning_rate=args.learning_rate)
```

