### PR TITLE
Make it easier to know in which file we have bad JSON data

### DIFF
--- a/lora/lora.py
+++ b/lora/lora.py
@@ -138,8 +138,22 @@ class Dataset:
 
 
 def load(args):
-    names = ("train", "valid", "test")
-    train, valid, test = (Dataset(Path(args.data) / f"{n}.jsonl") for n in names)
+    try:
+        train = Dataset(Path(args.data) / "train.jsonl")
+    except Exception as e:
+        print(f"Training set not built at {args.data}/train.jsonl ({e})")
+        raise
+    try:
+        valid = Dataset(Path(args.data) / "valid.jsonl")
+    except Exception as e:
+        print(f"Validation set not built at {args.data}/valid.jsonl ({e})")
+        raise
+    try:
+        test = Dataset(Path(args.data) / "test.jsonl")
+    except Exception as e:
+        print(f"Test set not built at {args.data}/test.jsonl ({e})")
+        raise
+
     if args.train and len(train) == 0:
         raise ValueError(
             "Training set not found or empty. Must provide training set for fine-tuning."

--- a/lora/lora.py
+++ b/lora/lora.py
@@ -138,21 +138,14 @@ class Dataset:
 
 
 def load(args):
-    try:
-        train = Dataset(Path(args.data) / "train.jsonl")
-    except Exception as e:
-        print(f"Training set not built at {args.data}/train.jsonl ({e})")
-        raise
-    try:
-        valid = Dataset(Path(args.data) / "valid.jsonl")
-    except Exception as e:
-        print(f"Validation set not built at {args.data}/valid.jsonl ({e})")
-        raise
-    try:
-        test = Dataset(Path(args.data) / "test.jsonl")
-    except Exception as e:
-        print(f"Test set not built at {args.data}/test.jsonl ({e})")
-        raise
+    def load_and_check(name):
+         dataset_path = Path(args.data) / f"{name}.jsonl"
+         try:
+             train = Dataset(dataset_path)
+         except Exception as e:
+             print(f"Unable to build dataset {dataset_path} ({e})")
+             raise
+    train, valid, test = (load_and_check(n) for n in names)
 
     if args.train and len(train) == 0:
         raise ValueError(

--- a/lora/lora.py
+++ b/lora/lora.py
@@ -145,6 +145,8 @@ def load(args):
          except Exception as e:
              print(f"Unable to build dataset {dataset_path} ({e})")
              raise
+
+    names = ("train", "valid", "test")
     train, valid, test = (load_and_check(n) for n in names)
 
     if args.train and len(train) == 0:


### PR DESCRIPTION
I was using `lora.py` to train Mistral and accidentally used corrupted JSONL files. My traceback looked like this:

```

Traceback (most recent call last):
  File "/Users/ovid/projects/llms/mlx-examples/lora/lora.py", line 328, in <module>
class Dataset:
    train_set, valid_set, test_set = load(args)
                                     ^^^^^^^^^^
  File "/Users/ovid/projects/llms/mlx-examples/lora/lora.py", line 142, in load
    train, valid, test = (Dataset(Path(args.data) / f"{n}.jsonl") for n in names)
    ^^^^^^^^^^^^^^^^^^
  File "/Users/ovid/projects/llms/mlx-examples/lora/lora.py", line 142, in <genexpr>
    train, valid, test = (Dataset(Path(args.data) / f"{n}.jsonl") for n in names)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ovid/projects/llms/mlx-examples/lora/lora.py", line 130, in __init__
    self._data = [json.loads(l) for l in fid]
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ovid/projects/llms/mlx-examples/lora/lora.py", line 130, in <listcomp>
    self._data = [json.loads(l) for l in fid]
                  ^^^^^^^^^^^^^
class Dataset:
  File "/opt/homebrew/Cellar/python@3.11/3.11.7_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.7_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.7_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
               ^^^^^^^^^^^^^^^^^^^^^^
json.decoder.JSONDecodeError: Expecting ',' delimiter: line 1 column 33 (char 32)
```

I can't tell from that which file was corrupted.

This PR adjust the `load` function to attempt to build each `train.jsonl`, `valid.jsonl`, and `test.jsonal` datasets separately. This allows me to add a line like the following before the traceback, telling me which file was corrupted.

```
Training set not built at /Users/ovid/projects/mistral/train.jsonl (Expecting ',' delimiter: line 1 column 33 (char 32))
```

No tests were written because:

1. It's a trivial change
2. I can't tell that this code is tested