### PR TITLE
LoRA: Extract the run function for easy use in scripts file

### DIFF
--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -7,7 +7,7 @@ import mlx.optimizers as optim
 import numpy as np
 from mlx.utils import tree_flatten
 
-from .tuner.trainer import TrainingArgs, evaluate, train
+from .tuner.trainer import TrainingArgs, TrainingCallback, evaluate, train
 from .tuner.utils import linear_to_lora_layers
 from .utils import generate, load
 
@@ -160,7 +160,7 @@ def load_dataset(args):
     return train, valid, test
 
 
-def run_lora(args):
+def run_lora(args, training_callback: TrainingCallback = None):
     np.random.seed(args.seed)
 
     print("Loading pretrained model")
@@ -206,6 +206,7 @@ def run_lora(args):
             optimizer=opt,
             train_dataset=train_set,
             val_dataset=valid_set,
+            training_callback=training_callback,
         )
 
     # Load the LoRA adapter weights which we assume should exist by this point

--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -160,10 +160,7 @@ def load_dataset(args):
     return train, valid, test
 
 
-if __name__ == "__main__":
-    parser = build_parser()
-    args = parser.parse_args()
-
+def run_lora(args):
     np.random.seed(args.seed)
 
     print("Loading pretrained model")
@@ -246,3 +243,10 @@ if __name__ == "__main__":
             prompt=args.prompt,
             verbose=True,
         )
+
+
+if __name__ == "__main__":
+    parser = build_parser()
+    args = parser.parse_args()
+
+    run_lora(args)

--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -160,7 +160,7 @@ def load_dataset(args):
     return train, valid, test
 
 
-def run_lora(args, training_callback: TrainingCallback = None):
+def run(args, training_callback: TrainingCallback = None):
     np.random.seed(args.seed)
 
     print("Loading pretrained model")
@@ -250,4 +250,4 @@ if __name__ == "__main__":
     parser = build_parser()
     args = parser.parse_args()
 
-    run_lora(args)
+    run(args)


### PR DESCRIPTION
Extracting the logic from `if __name__ == "__main__":` into a separate `run` function makes it easy to call the logic in the `lora.py` file from your own python scripts.

Below is a simple code example of my training scenario:

```py
import argparse
from mlx_lm import lora
from mlx_lm.tuner.trainer import TrainingCallback

def finetuning():
    # build args
    parser = lora.build_parser()
    args = parser.parse_args(args=[])
    args.model = "Qwen/Qwen1.5-1.8B-Chat"
    args.train = True

    # training
    wandb_callback = WandbCallback()
    lora.run(args, training_callback = wandb_callback)

if __name__ == "__main__":
   finetuning()
```


In addition to the command line, it's finally possible to fine-tune it by writing code.