### PR TITLE
Add metadata when saving safetensors

### DIFF
--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -113,7 +113,14 @@ def main(args):
     formatter = colorprint_by_t0 if args.colorize else None
 
     generate(
-        model, tokenizer, prompt, args.temp, args.max_tokens, True, formatter=formatter, top_p=args.top_p
+        model,
+        tokenizer,
+        prompt,
+        args.temp,
+        args.max_tokens,
+        True,
+        formatter=formatter,
+        top_p=args.top_p,
     )
 
 

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -498,7 +498,7 @@ def save_weights(
         shard_name = shard_file_format.format(i + 1, shards_count)
         shard_path = save_path / shard_name
 
-        mx.save_safetensors(str(shard_path), shard)
+        mx.save_safetensors(str(shard_path), shard, metadata={"format": "pt"})
 
         for weight_name in shard.keys():
             index_data["weight_map"][weight_name] = shard_name

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -498,7 +498,7 @@ def save_weights(
         shard_name = shard_file_format.format(i + 1, shards_count)
         shard_path = save_path / shard_name
 
-        mx.save_safetensors(str(shard_path), shard, metadata={"format": "pt"})
+        mx.save_safetensors(str(shard_path), shard, metadata={"format": "mlx"})
 
         for weight_name in shard.keys():
             index_data["weight_map"][weight_name] = shard_name


### PR DESCRIPTION
Add metadata format="pt" for safetensors so that model's are accessible to `transformers` users as well.

Tested locally for loading via transformers on a M3 Max MacBook Pro.

https://github.com/ml-explore/mlx-examples/issues/490