### PR TITLE
Prevent llms/mlx_lm from serving the local directory as a webserver

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -12,3 +12,4 @@ MLX Examples was developed with contributions from the following individuals:
 - Shunta Saito: Added support for PLaMo models.
 - Gabrijel Boduljak: Implemented `CLIP`.
 - Markus Enzweiler: Added the `cvae` examples.
+- Rasmus Kinnunen: Fixed a security hole in the `llms/mlx_lm` example

--- a/llms/mlx_lm/SERVER.md
+++ b/llms/mlx_lm/SERVER.md
@@ -4,7 +4,9 @@ You use `mlx-lm` to make an HTTP API for generating text with any supported
 model. The HTTP API is intended to be similar to the [OpenAI chat
 API](https://platform.openai.com/docs/api-reference).
 
-NOTE: mlx-lm is not recommended for production. It only implements basic security checks.
+> [!NOTE]  
+> The MLX LM server is not recommended for production as it only implements
+> basic security checks.
 
 Start the server with: 
 

--- a/llms/mlx_lm/SERVER.md
+++ b/llms/mlx_lm/SERVER.md
@@ -4,6 +4,8 @@ You use `mlx-lm` to make an HTTP API for generating text with any supported
 model. The HTTP API is intended to be similar to the [OpenAI chat
 API](https://platform.openai.com/docs/api-reference).
 
+NOTE: mlx-lm is not recommended for production. It only implements basic security checks.
+
 Start the server with: 
 
 ```shell

--- a/llms/mlx_lm/SERVER.md
+++ b/llms/mlx_lm/SERVER.md
@@ -65,5 +65,9 @@ curl localhost:8080/v1/chat/completions \
 
 - `top_p`: (Optional) A float specifying the nucleus sampling parameter.
   Defaults to `1.0`.
-- `repetition_penalty`: (Optional) Applies a penalty to repeated tokens. Defaults to `1.0`.
-- `repetition_context_size`: (Optional) The size of the context window for applying repetition penalty. Defaults to `20`.
+
+- `repetition_penalty`: (Optional) Applies a penalty to repeated tokens.
+  Defaults to `1.0`.
+
+- `repetition_context_size`: (Optional) The size of the context window for
+  applying repetition penalty. Defaults to `20`.

--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -115,7 +115,14 @@ def main(args):
     formatter = colorprint_by_t0 if args.colorize else None
 
     generate(
-        model, tokenizer, prompt, args.temp, args.max_tokens, True, formatter=formatter, top_p=args.top_p
+        model,
+        tokenizer,
+        prompt,
+        args.temp,
+        args.max_tokens,
+        True,
+        formatter=formatter,
+        top_p=args.top_p,
     )
 
 

--- a/llms/mlx_lm/merge.py
+++ b/llms/mlx_lm/merge.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import mlx.core as mx
+import mlx.nn as nn
 import numpy as np
 import yaml
 from mlx.utils import tree_flatten, tree_map
@@ -67,7 +68,7 @@ def slerp(t, w1, w2, eps=1e-5):
     return s1 * w1 + s2 * w2
 
 
-def merge_models(base_model, model, config):
+def merge_models(base_model: nn.Module, model: nn.Module, config: dict):
     method = config.get("method", None)
     if method != "slerp":
         raise ValueError(f"Merge method {method} not supported")

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -158,6 +158,14 @@ def create_completion_chunk_response(completion_id, requested_model, next_chunk)
 
 
 class APIHandler(BaseHTTPRequestHandler):
+
+    def __init__(self, *args, **kwargs):
+        # Prevent exposing local directory by deleting HEAD and GET methods
+        delattr(self, "do_HEAD")
+        delattr(self, "do_GET")
+
+        super().__init__(*args, **kwargs)
+
     def _set_headers(self, status_code=200):
         self.send_response(status_code)
         self.send_header("Content-type", "application/json")

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -314,7 +314,7 @@ class APIHandler(BaseHTTPRequestHandler):
         self.wfile.write(f"data: [DONE]\n\n".encode())
         self.wfile.flush()
 
-    def handle_chat_completions(self, post_data):
+    def handle_chat_completions(self, post_data: bytes):
         body = json.loads(post_data.decode("utf-8"))
         chat_id = f"chatcmpl-{uuid.uuid4()}"
         if hasattr(_tokenizer, "apply_chat_template") and _tokenizer.chat_template:
@@ -374,7 +374,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 create_chat_chunk_response,
             )
 
-    def handle_completions(self, post_data):
+    def handle_completions(self, post_data: bytes):
         body = json.loads(post_data.decode("utf-8"))
         completion_id = f"cmpl-{uuid.uuid4()}"
         prompt_text = body["prompt"]

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -235,7 +235,7 @@ class APIHandler(BaseHTTPRequestHandler):
         text = _tokenizer.decode(tokens)
         return response_creator(response_id, requested_model, prompt, tokens, text)
 
-    def hanlde_stream(
+    def handle_stream(
         self,
         prompt: mx.array,
         response_id: str,
@@ -360,7 +360,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 create_chat_response,
             )
         else:
-            self.hanlde_stream(
+            self.handle_stream(
                 prompt,
                 chat_id,
                 requested_model,
@@ -411,7 +411,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 create_completion_response,
             )
         else:
-            self.hanlde_stream(
+            self.handle_stream(
                 prompt,
                 completion_id,
                 requested_model,

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -430,7 +430,10 @@ class APIHandler(BaseHTTPRequestHandler):
 def run(host: str, port: int, server_class=HTTPServer, handler_class=APIHandler):
     server_address = (host, port)
     httpd = server_class(server_address, handler_class)
-    warnings.warn("Server is not recommended for production. It only implements basic security checks.")
+    warnings.warn(
+        "mlx_lm.server is not recommended for production as "
+        "it only implements basic security checks."
+    )
     print(f"Starting httpd at {host} on port {port}...")
     httpd.serve_forever()
 

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import time
 import uuid
+import warnings
 from collections import namedtuple
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Callable, List, Optional
@@ -429,6 +430,7 @@ class APIHandler(BaseHTTPRequestHandler):
 def run(host: str, port: int, server_class=HTTPServer, handler_class=APIHandler):
     server_address = (host, port)
     httpd = server_class(server_address, handler_class)
+    warnings.warn("Server is not recommended for production. It only implements basic security checks.")
     print(f"Starting httpd at {host} on port {port}...")
     httpd.serve_forever()
 

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -390,7 +390,7 @@ def load(
 
 def fetch_from_hub(
     model_path: Path, lazy: bool = False
-) -> Tuple[Dict, dict, PreTrainedTokenizer]:
+) -> Tuple[nn.Module, dict, PreTrainedTokenizer]:
     model = load_model(model_path, lazy)
 
     config = AutoConfig.from_pretrained(model_path)


### PR DESCRIPTION
By default BaseHTTPRequestHandler serves the local directory as a website using the do_HEAD and do_GET methods. Should definitely not be the case. Although there are definitely bigger issues at hand if somebody runs these examples in production before looking at them, I'd still suggest having a security policy

Threw in some type hint fixes as a treat :)