### PR TITLE
LoRA: adapter file Support path information

### DIFF
--- a/llms/mlx_lm/tuner/trainer.py
+++ b/llms/mlx_lm/tuner/trainer.py
@@ -146,7 +146,9 @@ def train(
     def check_checkpoints_path(adapter_file):
         checkpoints_path = "checkpoints"
         if os.path.dirname(adapter_file):
-            checkpoints_path = os.path.join(os.path.dirname(adapter_file), "checkpoints")
+            checkpoints_path = os.path.join(
+                os.path.dirname(adapter_file), "checkpoints"
+            )
 
         if not os.path.exists(checkpoints_path):
             os.makedirs(checkpoints_path)
@@ -250,7 +252,9 @@ def train(
 
         # Save adapter weights if needed
         if (it + 1) % args.steps_per_save == 0:
-            checkpoint_adapter_file = f"{adapter_path}/{it + 1}_{os.path.basename(args.adapter_file)}"
+            checkpoint_adapter_file = (
+                f"{adapter_path}/{it + 1}_{os.path.basename(args.adapter_file)}"
+            )
             save_adapter(model=model, adapter_file=checkpoint_adapter_file)
             print(
                 f"Iter {it + 1}: Saved adapter weights to {os.path.join(checkpoint_adapter_file)}."

--- a/llms/mlx_lm/tuner/trainer.py
+++ b/llms/mlx_lm/tuner/trainer.py
@@ -1,6 +1,6 @@
-import os
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -143,17 +143,15 @@ def train(
 ):
     print(f"Starting training..., iters: {args.iters}")
 
-    def check_checkpoints_path(adapter_file):
-        checkpoints_path = "checkpoints"
-        if os.path.dirname(adapter_file):
-            checkpoints_path = os.path.join(
-                os.path.dirname(adapter_file), "checkpoints"
-            )
+    def check_checkpoints_path(adapter_file) -> str:
+        checkpoints_path = Path("checkpoints")
+        if Path(adapter_file).parent:
+            checkpoints_path = Path(adapter_file).parent / "checkpoints"
 
-        if not os.path.exists(checkpoints_path):
-            os.makedirs(checkpoints_path)
+        if not checkpoints_path.exists():
+            checkpoints_path.mkdir(parents=True)
 
-        return checkpoints_path
+        return str(checkpoints_path)
 
     # Create checkpoints directory if it does not exist
     adapter_path = check_checkpoints_path(args.adapter_file)
@@ -253,16 +251,16 @@ def train(
         # Save adapter weights if needed
         if (it + 1) % args.steps_per_save == 0:
             checkpoint_adapter_file = (
-                f"{adapter_path}/{it + 1}_{os.path.basename(args.adapter_file)}"
+                f"{adapter_path}/{it + 1}_{Path(args.adapter_file).name}"
             )
             save_adapter(model=model, adapter_file=checkpoint_adapter_file)
             print(
-                f"Iter {it + 1}: Saved adapter weights to {os.path.join(checkpoint_adapter_file)}."
+                f"Iter {it + 1}: Saved adapter weights to {checkpoint_adapter_file}."
             )
 
     # save final adapter weights
     save_adapter(model=model, adapter_file=args.adapter_file)
-    print(f"Saved final adapter weights to {os.path.join(args.adapter_file)}.")
+    print(f"Saved final adapter weights to {args.adapter_file}.")
 
 
 def save_adapter(

--- a/llms/mlx_lm/tuner/trainer.py
+++ b/llms/mlx_lm/tuner/trainer.py
@@ -143,7 +143,7 @@ def train(
 ):
     print(f"Starting training..., iters: {args.iters}")
 
-    def check_checkpoints_path(adapter_file) -> str:
+    def checkpoints_path(adapter_file) -> str:
         checkpoints_path = Path("checkpoints")
         if Path(adapter_file).parent:
             checkpoints_path = Path(adapter_file).parent / "checkpoints"
@@ -153,7 +153,7 @@ def train(
         return str(checkpoints_path)
 
     # Create checkpoints directory if it does not exist
-    adapter_path = check_checkpoints_path(args.adapter_file)
+    adapter_path = checkpoints_path(args.adapter_file)
 
     # Create value and grad function for loss
     loss_value_and_grad = nn.value_and_grad(model, loss)

--- a/llms/mlx_lm/tuner/trainer.py
+++ b/llms/mlx_lm/tuner/trainer.py
@@ -253,9 +253,7 @@ def train(
                 f"{adapter_path}/{it + 1}_{Path(args.adapter_file).name}"
             )
             save_adapter(model=model, adapter_file=checkpoint_adapter_file)
-            print(
-                f"Iter {it + 1}: Saved adapter weights to {checkpoint_adapter_file}."
-            )
+            print(f"Iter {it + 1}: Saved adapter weights to {checkpoint_adapter_file}.")
 
     # save final adapter weights
     save_adapter(model=model, adapter_file=args.adapter_file)

--- a/llms/mlx_lm/tuner/trainer.py
+++ b/llms/mlx_lm/tuner/trainer.py
@@ -148,8 +148,7 @@ def train(
         if Path(adapter_file).parent:
             checkpoints_path = Path(adapter_file).parent / "checkpoints"
 
-        if not checkpoints_path.exists():
-            checkpoints_path.mkdir(parents=True)
+        checkpoints_path.mkdir(parents=True, exist_ok=True)
 
         return str(checkpoints_path)
 

--- a/llms/mlx_lm/tuner/trainer.py
+++ b/llms/mlx_lm/tuner/trainer.py
@@ -143,9 +143,18 @@ def train(
 ):
     print(f"Starting training..., iters: {args.iters}")
 
+    def check_checkpoints_path(adapter_file):
+        checkpoints_path = "checkpoints"
+        if os.path.dirname(adapter_file):
+            checkpoints_path = os.path.join(os.path.dirname(adapter_file), "checkpoints")
+
+        if not os.path.exists(checkpoints_path):
+            os.makedirs(checkpoints_path)
+
+        return checkpoints_path
+
     # Create checkpoints directory if it does not exist
-    if not os.path.exists("checkpoints"):
-        os.makedirs("checkpoints")
+    adapter_path = check_checkpoints_path(args.adapter_file)
 
     # Create value and grad function for loss
     loss_value_and_grad = nn.value_and_grad(model, loss)
@@ -241,7 +250,7 @@ def train(
 
         # Save adapter weights if needed
         if (it + 1) % args.steps_per_save == 0:
-            checkpoint_adapter_file = f"checkpoints/{it + 1}_{args.adapter_file}"
+            checkpoint_adapter_file = f"{adapter_path}/{it + 1}_{os.path.basename(args.adapter_file)}"
             save_adapter(model=model, adapter_file=checkpoint_adapter_file)
             print(
                 f"Iter {it + 1}: Saved adapter weights to {os.path.join(checkpoint_adapter_file)}."


### PR DESCRIPTION
Enable the passed in args.adapter_file to contain path information, such as passing in "build/adapters.npz". The storage path of the final file is as follows:

```
.
├── build
│   ├── adapters.npz
│   └── checkpoints
│       ├── 100_adapters.npz
│       └── 200_adapters.npz
```