### PR TITLE
Update README.md

### DIFF
--- a/whisper/README.md
+++ b/whisper/README.md
@@ -39,8 +39,20 @@ To generate a 4-bit quantized model, use `-q`. For a full list of options:
 python convert.py --help
 ```
 
-By default, the conversion script will make the directory `mlx_models/tiny`
-and save the converted `weights.npz` and `config.json` there.
+By default, the conversion script will make the directory `mlx_models`
+and save the converted `weights.npz` and `config.json` there. Note that
+this does not automatically save different versions in this folder.
+However, the downloaded models are cached for future use. 
+
+Consider a scripted run (e.g. BASH, zsh) like the below example to stream-line filemaking:
+
+```
+model="tiny.en"
+python convert.py --torch-name-or-path ${model} --dtype float16 --mlx-path mlx_models/${model}_fp16
+python convert.py --torch-name-or-path ${model} --dtype float32 --mlx-path mlx_models/${model}_fp32
+python convert.py --torch-name-or-path ${model} -q --q_bits 4 --mlx-path mlx_models/${model}_quantized_4bits
+```
+Another solution would be to implement a loop that executes those commands for each of a list of Models. 
 
 ### Run
 


### PR DESCRIPTION
The default behaviour of where the convert.py saved files was wrong. It also was inconsistent with how the later script test.py is trying to use them (and assuming naming convention). 

I don't actually see a quick way to automate this since--as written--the  target directory is set directly by an argument. It would probably be best to rewrite it so that the argument is used as an override variable, but the default behaviour is to construct a file path based on set and unset arugments. This also is complex because "defaults" are assumed in the naming convention as well.