### PR TITLE
Print huggingface repo url

### DIFF
--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -470,6 +470,7 @@ def upload_to_hub(path: str, upload_repo: str, hf_path: str):
         repo_id=upload_repo,
         repo_type="model",
     )
+    print(f"Upload successful, go to https://huggingface.co/{upload_repo} for details.")
 
 
 def save_weights(


### PR DESCRIPTION
Print the URL address of the uploaded Hugging Face repository, which can be opened by clicking on the link as a quick jump in the terminal, as follows:

<img width="778" alt="image" src="https://github.com/ml-explore/mlx-examples/assets/6247142/bf4ec77a-d8d5-4b69-bddb-389ec9347c04">
