### PR TITLE
Allow contributors to `self-assign` issues with GitHub workflow

### DIFF
--- a/.github/workflows/selfassign.yml
+++ b/.github/workflows/selfassign.yml
@@ -1,0 +1,24 @@
+# Allow users to automatically tag themselves to issues
+#
+# Usage:
+#  - a github user (a member of the repo) needs to comment
+#    with "#self-assign" on an issue to self-assigned the issue.
+#---------------------------------------------------------------
+
+name: Self-assign
+on:
+  issue_comment:
+    types: created
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event.comment.body == '#take' ||
+       github.event.comment.body == '#self-assign')
+    steps:
+      - run: |
+          echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' \
+                  https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
+          echo "Done 🔥 "


### PR DESCRIPTION
This github workflow allows users to automatically tag themselves to issues.

Usage:
- a github user (a member of the repo) needs to comment with `#self-assign` or `#take` on an issue to self-assign the issue.

> :bell: **Note**: I have previously added this workflow to other repositories to reduce chores for the repo-admins. Please see here for some repositories where this workflow is in use: 
> - https://github.com/unionai-oss/unionml/pull/136 
> - https://github.com/pytorch/tensordict/issues/282
> - https://github.com/goodmami/wn/issues/185
> - https://github.com/JohnSnowLabs/langtest/issues/319

:bulb: Closes #537