### PR TITLE
Predict stop sequence matches during streaming

### DIFF
--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -66,7 +66,7 @@ def sequence_overlap(s1: Sequence, s2: Sequence) -> bool:
         bool: If the two sequences have overlap
     """
     max_overlap = min(len(s1), len(s2))
-    return any(s1[-i:] == s2[:i] for i in range(1, max_overlap))
+    return any(s1[-i:] == s2[:i] for i in range(1, max_overlap + 1))
 
 
 def convert_chat(messages: List[dict], role_mapping: Optional[dict] = None):

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -535,6 +535,7 @@ class APIHandler(BaseHTTPRequestHandler):
             self.wfile.flush()
 
         # check is there any remaining text to send
+        detokenizer.finalize()
         last_segment = detokenizer.last_segment
         if last_segment:
             if stop_sequence_suffix is not None:

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -67,7 +67,7 @@ def sequence_overlap(s1: Sequence, s2: Sequence) -> int:
         int: The amount of overlap between s1 and s2
     """
     # Count down from the length of the smaller list -> Checks for larger overlaps first
-    for index in range(min(len(s1), len(s1)), 0, -1):
+    for index in range(min(len(s1), len(s2)), 0, -1):
         # Check if they have index amount of overlap
         if s1[-index:] == s2[:index]:
             return index

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -477,12 +477,13 @@ class APIHandler(BaseHTTPRequestHandler):
         stop_id_sequences: List[List[int]],
     ):
         """
-        Generate response to prompt and foward it to the client using a Server Sent Events (SSE) stream.
+        Generate response to prompt and foward it to the client using a Server
+        Sent Events (SSE) stream.
 
         Args:
             prompt (mx.array): The prompt, in token form inside of a mlx array
-            stop_id_sequences (List[List[int]]):
-                A list of stop words passed to the stopping_criteria function
+            stop_id_sequences (List[List[int]]): A list of stop words passed to
+              the stopping_criteria function
         """
         # No additional headers are needed, call end_headers
         self.end_headers()
@@ -521,8 +522,8 @@ class APIHandler(BaseHTTPRequestHandler):
                     )
                 break
 
-            # If the end of tokens overlaps with a stop sequence
-            # Generate new tokens until we know if the stop sequence is hit or not
+            # If the end of tokens overlaps with a stop sequence, generate new
+            # tokens until we know if the stop sequence is hit or not
             if any(
                 (sequence_overlap(tokens, sequence) for sequence in stop_id_sequences)
             ):

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -56,11 +56,11 @@ def stopping_criteria(
 
 def sequence_overlap(s1: Sequence, s2: Sequence) -> bool:
     """
-    Checks if s1 has overlap with s2
+    Checks if a suffix of s1 has overlap with a prefix of s2
 
     Args:
-        s1 (Sequence): The first sequence, which end is checked
-        s2 (Sequence): The second sequence, which beginning is checked
+        s1 (Sequence): The first sequence
+        s2 (Sequence): The second sequence
 
     Returns:
         bool: If the two sequences have overlap
@@ -535,13 +535,13 @@ class APIHandler(BaseHTTPRequestHandler):
             self.wfile.flush()
 
         # check is there any remaining text to send
-        if stop_sequence_buffer:
-            next_chunk = (
-                detokenizer.last_segment
-                if stop_sequence_suffix is None
-                else detokenizer.last_segment[: -len(stop_sequence_suffix)]
-            )
-            response = self.generate_response(next_chunk, "length")
+        last_segment = detokenizer.last_segment
+        if last_segment:
+            if stop_sequence_suffix is not None:
+                last_segment = last_segment[: -len(stop_sequence_suffix)]
+            response = self.generate_response(last_segment, "length")
+            self.wfile.write(f"data: {json.dumps(response)}\n\n".encode())
+            self.wfile.flush()
 
         if self.stream_options is not None and self.stream_options["include_usage"]:
             response = self.completion_usage_response(len(prompt), len(tokens))

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -54,24 +54,19 @@ def stopping_criteria(
     return StopCondition(stop_met=False, trim_length=0)
 
 
-def sequence_overlap(s1: Sequence, s2: Sequence) -> int:
+def sequence_overlap(s1: Sequence, s2: Sequence) -> bool:
     """
-    Check how much overlap two sequences have.
-        Only checks the end of s1 overlapping the start of s2
+    Checks if s1 has overlap with s2
 
     Args:
         s1 (Sequence): The first sequence, which end is checked
         s2 (Sequence): The second sequence, which beginning is checked
 
     Returns:
-        int: The amount of overlap between s1 and s2
+        bool: If the two sequences have overlap
     """
-    # Count down from the length of the smaller list -> Checks for larger overlaps first
-    for index in range(min(len(s1), len(s2)), 0, -1):
-        # Check if they have index amount of overlap
-        if s1[-index:] == s2[:index]:
-            return index
-    return 0
+    max_overlap = min(len(s1), len(s2))
+    return any(s1[-i:] == s2[:i] for i in range(1, max_overlap))
 
 
 def convert_chat(messages: List[dict], role_mapping: Optional[dict] = None):

--- a/llms/tests/test_server.py
+++ b/llms/tests/test_server.py
@@ -1,3 +1,4 @@
+# Copyright © 2024 Apple Inc.
 import http
 import threading
 import unittest
@@ -75,6 +76,18 @@ class TestServer(unittest.TestCase):
         response_body = response.text
         self.assertIn("id", response_body)
         self.assertIn("choices", response_body)
+
+    def test_sequence_overlap(self):
+        from mlx_lm.server import sequence_overlap
+
+        self.assertTrue(sequence_overlap([1], [1]))
+        self.assertTrue(sequence_overlap([1, 2], [1, 2]))
+        self.assertTrue(sequence_overlap([1, 3], [3, 4]))
+        self.assertTrue(sequence_overlap([1, 2, 3], [2, 3]))
+
+        self.assertFalse(sequence_overlap([1], [2]))
+        self.assertFalse(sequence_overlap([1, 2], [3, 4]))
+        self.assertFalse(sequence_overlap([1, 2, 3], [4, 1, 2, 3]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When streaming using mlx_lm/server.py we should predict potential stop sequence matches, and generate tokens until we know that there is no match. This prevents the server from sending parts of a stop sequence to the client before it finds the match. 

Fixes #524 

My implementation adds a new function called "sequence_overlap" which checks how much sequence 1 has overlap with sequence 2. It checks for larger overlaps first, and returns the overlap as an integer.

The server checks for overlaps, and generates more tokens before allowing the server to send them.
```python
if any((sequence_overlap(tokens, sequence) for sequence in stop_id_sequences)):
    continue
```
The sequence_overlap implementation can be tested with this example:
```python
from typing import Sequence


def sequence_overlap(s1: Sequence, s2: Sequence) -> int:
    """
    Check how much overlap two sequences have.
        Only checks the end of s1 overlapping the start of s2

    Args:
        s1 (Sequence): The first sequence, which end is checked
        s2 (Sequence): The second sequence, which beginning is checked

    Returns:
        int: The amount of overlap between s1 and s2
    """
    # Count down from the length of the smaller list -> Checks for larger overlaps first
    for index in range(min(len(s1), len(s2)), 0, -1):
        # Check if they have index amount of overlap
        if s1[-index:] == s2[:index]:
            return index
    return 0


stop_sequence = [27, 28, 29]

tokens = []
new_tokens = []

for token in range(50):
    tokens.append(token)
    new_tokens.append(token)

    # This should always be the first check, since it needs to be performed on every token
    if len(tokens) >= len(stop_sequence) and tokens[-len(stop_sequence):] == stop_sequence:
        print("Contains stop sequence:", new_tokens)
        tokens = tokens[:len(tokens) - len(stop_sequence)]
        new_tokens.clear()
        break

    # Generate tokens until we know that tokens does not contain stop sequence
    if sequence_overlap(tokens, stop_sequence):
        print("Found a possible start to a stop sequence:", new_tokens)
        continue

    # Process new tokens
    print("Processing new tokens:", new_tokens)
    new_tokens.clear()

# In the case that the generation ends with the start of a stop sequence
# We need to process leftovers, since it would call continue until a break
if new_tokens:
    print("Processing leftover new tokens", new_tokens)
    new_tokens.clear()

print("Full sequence:", tokens)

```