### PR TITLE
Support for OpenAI’s fine-tuning dataset format

### DIFF
--- a/llms/mlx_lm/LORA.md
+++ b/llms/mlx_lm/LORA.md
@@ -141,37 +141,36 @@ loader expects a `test.jsonl` in the data directory.
 Currently, `*.jsonl` files support three data formats: `chat`,
 `completions`, and `text`. Here are three examples of these formats:
 
-- `chat`
+`chat`:
   
-  ```jsonl
-  {"messages": [
-      {"role": "system", "content": "You are a helpful assistant." },
-      {"role": "user", "content": "Hello."},
-      {"role": "assistant", "content": "How can I assistant you today."}
-    ]}
-  ```
+```jsonl
+{"messages": [
+  {"role": "system", "content": "You are a helpful assistant." },
+  {"role": "user", "content": "Hello."},
+  {"role": "assistant", "content": "How can I assistant you today."}
+]}
+```
 
-- `completions`
+`completions`:
   
-  ```jsonl
-  {"prompt": "What is the capital of France?", "completion": "Paris."}
-  ```
+```jsonl
+{"prompt": "What is the capital of France?", "completion": "Paris."}
+```
 
-- `text`
+`text`:
 
-  ```jsonl
-  {"text": "This is an example for the model."}
-  ```
+```jsonl
+{"text": "This is an example for the model."}
+```
 
-Note, the format is automatically determined by the dataset. Also, keys in each
-line not expected by the loader will be ignored.
+Note, the format is automatically determined by the dataset. Note also, keys in
+each line not expected by the loader will be ignored.
 
 For the `chat` and `completions` formats, Hugging Face [chat
-templates](https://huggingface.co/blog/chat-templates) are used. This apply the
-model's chat-templates definition by default. However if the model does not
-have a chat template, then Hugging Face will use a default template. For
-example, the final text of the `chat` example above with Hugging
-Face's default template becomes:
+templates](https://huggingface.co/blog/chat-templates) are used. This applies
+the model's chat template by default. If the model does not have a chat
+template, then Hugging Face will use a default. For example, the final text in
+the `chat` example above with Hugging Face's default template becomes:
 
 ```text
 <|im_start|>system
@@ -182,9 +181,9 @@ Hello.<|im_end|>
 How can I assistant you today.<|im_end|>
 ```
 
-If you are unsure of the format to use, the `chat` or `completions`
-are good to start with. For specific requirements on the format of the dataset,
-use the `text` format to assemble the content yourself.
+If you are unsure of the format to use, the `chat` or `completions` are good to
+start with. For custom requirements on the format of the dataset, use the
+`text` format to assemble the content yourself.
 
 ## Memory Issues
 

--- a/llms/mlx_lm/LORA.md
+++ b/llms/mlx_lm/LORA.md
@@ -147,7 +147,7 @@ Currently, `*.jsonl` files support three data formats: `chat`,
 {"messages": [
   {"role": "system", "content": "You are a helpful assistant." },
   {"role": "user", "content": "Hello."},
-  {"role": "assistant", "content": "How can I assistant you today."}
+  {"role": "assistant", "content": "How can I assistant you today."},
 ]}
 ```
 

--- a/llms/mlx_lm/LORA.md
+++ b/llms/mlx_lm/LORA.md
@@ -138,36 +138,40 @@ For fine-tuning (`--train`), the data loader expects a `train.jsonl` and a
 `valid.jsonl` to be in the data directory. For evaluation (`--test`), the data
 loader expects a `test.jsonl` in the data directory. 
 
-Currently, `*.jsonl` files support three data formats, namely conversations format, 
-prompt completion pair format, and text format. The differences among these formats 
-are as follows:
+Currently, `*.jsonl` files support three data formats: `chat`,
+`completions`, and `text`. Here are three examples of these formats:
 
-- conversations
+- `chat`
   
   ```jsonl
-  {"messages": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "Hello."}, {"role": "assistant", "content": "How can I assistant you today."}]}
+  {"messages": [
+      {"role": "system", "content": "You are a helpful assistant." },
+      {"role": "user", "content": "Hello."},
+      {"role": "assistant", "content": "How can I assistant you today."}
+    ]}
   ```
 
-- prompt completion pair
+- `completions`
   
   ```jsonl
   {"prompt": "What is the capital of France?", "completion": "Paris."}
   ```
 
-- Text
+- `text`
 
   ```jsonl
   {"text": "This is an example for the model."}
   ```
 
-Note, other keys will be ignored by the loader.
+Note, the format is automatically determined by the dataset. Also, keys in each
+line not expected by the loader will be ignored.
 
-For conversations and prompt completion pair, Hugging Face [Chat Templates](https://huggingface.co/blog/chat-templates)
-are used to assemble the corresponding text content. This assembly method will prioritize 
-using the foundation model's chat-templates definition. If the foundation model does not define a 
-chat-template, then Hugging Face will assemble using some default chat-templates. 
-For example, the text form of the aforementioned conversations assembled with Hugging Face's 
-default format is:
+For the `chat` and `completions` formats, Hugging Face [chat
+templates](https://huggingface.co/blog/chat-templates) are used. This apply the
+model's chat-templates definition by default. However if the model does not
+have a chat template, then Hugging Face will use a default template. For
+example, the final text of the `chat` example above with Hugging
+Face's default template becomes:
 
 ```text
 <|im_start|>system
@@ -178,11 +182,9 @@ Hello.<|im_end|>
 How can I assistant you today.<|im_end|>
 ```
 
-Note, the default chat-template of Hugging Face's version may vary.
-
-If you are unsure of which format of the dataset you should use, it is recommended to use 
-either conversations or prompt completion pair format. If you have specific requirements for 
-the format of the dataset, you can use the Text format to assemble any content yourself.
+If you are unsure of the format to use, the `chat` or `completions`
+are good to start with. For specific requirements on the format of the dataset,
+use the `text` format to assemble the content yourself.
 
 ## Memory Issues
 

--- a/llms/mlx_lm/LORA.md
+++ b/llms/mlx_lm/LORA.md
@@ -136,14 +136,53 @@ correct format.
 
 For fine-tuning (`--train`), the data loader expects a `train.jsonl` and a
 `valid.jsonl` to be in the data directory. For evaluation (`--test`), the data
-loader expects a `test.jsonl` in the data directory. Each line in the `*.jsonl`
-file should look like:
+loader expects a `test.jsonl` in the data directory. 
 
-```
-{"text": "This is an example for the model."}
-```
+Currently, `*.jsonl` files support three data formats, namely conversations format, 
+prompt completion pair format, and text format. The differences among these formats 
+are as follows:
+
+- conversations
+  
+  ```jsonl
+  {"messages": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "Hello."}, {"role": "assistant", "content": "How can I assistant you today."}]}
+  ```
+
+- prompt completion pair
+  
+  ```jsonl
+  {"prompt": "What is the capital of France?", "completion": "Paris."}
+  ```
+
+- Text
+
+  ```jsonl
+  {"text": "This is an example for the model."}
+  ```
 
 Note, other keys will be ignored by the loader.
+
+For conversations and prompt completion pair, Hugging Face [Chat Templates](https://huggingface.co/blog/chat-templates)
+are used to assemble the corresponding text content. This assembly method will prioritize 
+using the base model's chat-templates definition. If the base model does not define a 
+corresponding template, then Hugging Face will assemble using some default chat-templates. 
+For example, the text form of the aforementioned conversations assembled with Hugging Face's 
+default format is:
+
+```text
+<|im_start|>system
+You are a helpful assistant.<|im_end|>
+<|im_start|>user
+Hello.<|im_end|>
+<|im_start|>assistant
+How can I assistant you today.<|im_end|>
+```
+
+Note, the default chat-template of Hugging Face's version may vary.
+
+If you are unsure of which format of the dataset you should use, it is recommended to use 
+either conversations or prompt completion pair format. If you have specific requirements for 
+the format of the dataset, you can use the Text format to assemble any content yourself.
 
 ## Memory Issues
 

--- a/llms/mlx_lm/LORA.md
+++ b/llms/mlx_lm/LORA.md
@@ -164,8 +164,8 @@ Note, other keys will be ignored by the loader.
 
 For conversations and prompt completion pair, Hugging Face [Chat Templates](https://huggingface.co/blog/chat-templates)
 are used to assemble the corresponding text content. This assembly method will prioritize 
-using the base model's chat-templates definition. If the base model does not define a 
-corresponding template, then Hugging Face will assemble using some default chat-templates. 
+using the foundation model's chat-templates definition. If the foundation model does not define a 
+chat-template, then Hugging Face will assemble using some default chat-templates. 
 For example, the text form of the aforementioned conversations assembled with Hugging Face's 
 default format is:
 

--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -152,6 +152,7 @@ def print_trainable_parameters(model):
         f"({trainable_p:.3f}M/{total_p:.3f}M)"
     )
 
+
 def run(args, training_callback: TrainingCallback = None):
     np.random.seed(args.seed)
 

--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -166,7 +166,7 @@ def run(args, training_callback: TrainingCallback = None):
     print_trainable_parameters(model)
 
     print("Loading datasets")
-    train_set, valid_set, test_set = load_dataset(args)
+    train_set, valid_set, test_set = load_dataset(args, tokenizer)
 
     # Resume training the given adapters.
     if args.resume_adapter_file is not None:

--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -12,9 +12,9 @@ import numpy as np
 import yaml
 from mlx.utils import tree_flatten
 
+from .tuner.datasets import load_dataset
 from .tuner.trainer import TrainingArgs, TrainingCallback, evaluate, train
 from .tuner.utils import linear_to_lora_layers
-from .tuner.datasets import load_dataset
 from .utils import load
 
 yaml_loader = yaml.SafeLoader

--- a/llms/mlx_lm/requirements.txt
+++ b/llms/mlx_lm/requirements.txt
@@ -3,3 +3,4 @@ numpy
 transformers>=4.38.0
 protobuf
 pyyaml
+jinja2

--- a/llms/mlx_lm/tuner/datasets.py
+++ b/llms/mlx_lm/tuner/datasets.py
@@ -77,8 +77,13 @@ def create_dataset(file_path: Path, tokenizer: PreTrainedTokenizer = None):
         return ChatDataset(file_path, tokenizer)
     elif "prompt" in first_obj and "completion" in first_obj:
         return PromptCompletionDataset(file_path, tokenizer)
-    else:
+    elif "text" in first_obj:
         return Dataset(file_path)
+    else:
+        raise ValueError(
+            "Unsupported data format, please check the [supported "
+            "formats](https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/LORA.md#data)."
+        )
 
 
 def load_dataset(args, tokenizer: PreTrainedTokenizer):

--- a/llms/mlx_lm/tuner/datasets.py
+++ b/llms/mlx_lm/tuner/datasets.py
@@ -55,7 +55,7 @@ class PromptCompletionDataset(Dataset):
         self._tokenizer = tokenizer
 
     def __getitem__(self, idx: int):
-        data = self._data[idx][self._key]
+        data = self._data[idx]
         prompt = data["prompt"]
         completion = data["completion"]
         text = self._tokenizer.apply_chat_template(

--- a/llms/mlx_lm/tuner/datasets.py
+++ b/llms/mlx_lm/tuner/datasets.py
@@ -35,16 +35,13 @@ class ChatDataset(Dataset):
     def __init__(self, path: Path, tokenizer: PreTrainedTokenizer):
         super().__init__(path, key="messages")
         self._tokenizer = tokenizer
-        self._texts = []
-        for data in self._data:
-            messages = data[self._key]
-            text = self._tokenizer.apply_chat_template(
-                messages, tokenize=False, add_generation_prompt=True
-            )
-            self._texts.append(text)
 
     def __getitem__(self, idx: int):
-        return self._texts[idx]
+        messages = self._data[idx][self._key]
+        text = self._tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        return text
 
 
 class PromptCompletionDataset(Dataset):
@@ -56,22 +53,20 @@ class PromptCompletionDataset(Dataset):
     def __init__(self, path: Path, tokenizer: PreTrainedTokenizer):
         super().__init__(path, key=None)
         self._tokenizer = tokenizer
-        self._texts = []
-        for data in self._data:
-            prompt = data["prompt"]
-            completion = data["completion"]
-            text = self._tokenizer.apply_chat_template(
-                [
-                    {"role": "user", "content": prompt},
-                    {"role": "assistant", "content": completion},
-                ],
-                tokenize=False,
-                add_generation_prompt=True,
-            )
-            self._texts.append(text)
 
     def __getitem__(self, idx: int):
-        return self._texts[idx]
+        data = self._data[idx][self._key]
+        prompt = data["prompt"]
+        completion = data["completion"]
+        text = self._tokenizer.apply_chat_template(
+            [
+                {"role": "user", "content": prompt},
+                {"role": "assistant", "content": completion},
+            ],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        return text
 
 
 def create_dataset(file_path: Path, tokenizer: PreTrainedTokenizer = None):

--- a/llms/mlx_lm/tuner/datasets.py
+++ b/llms/mlx_lm/tuner/datasets.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+
+class Dataset:
+    """
+    Light-weight wrapper to hold lines from a jsonl file
+    """
+
+    def __init__(self, path: Path, key: str = "text"):
+        if not path.exists():
+            self._data = None
+        else:
+            with open(path, "r") as fid:
+                self._data = [json.loads(l) for l in fid]
+        self._key = key
+
+    def __getitem__(self, idx: int):
+        return self._data[idx][self._key]
+
+    def __len__(self):
+        if self._data is None:
+            return 0
+        return len(self._data)
+
+
+def load_dataset(args):
+    names = ("train", "valid", "test")
+    train, valid, test = (Dataset(Path(args.data) / f"{n}.jsonl") for n in names)
+    if args.train and len(train) == 0:
+        raise ValueError(
+            "Training set not found or empty. Must provide training set for fine-tuning."
+        )
+    if args.train and len(valid) == 0:
+        raise ValueError(
+            "Validation set not found or empty. Must provide validation set for fine-tuning."
+        )
+    if args.test and len(test) == 0:
+        raise ValueError(
+            "Test set not found or empty. Must provide test set for evaluation."
+        )
+    return train, valid, test

--- a/llms/tests/test_datsets.py
+++ b/llms/tests/test_datsets.py
@@ -1,0 +1,81 @@
+# Copyright © 2024 Apple Inc.
+
+import json
+import os
+import tempfile
+import types
+import unittest
+
+from mlx_lm.tuner import datasets
+from transformers import AutoTokenizer
+
+HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
+
+
+class TestDatasets(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_dir_fid = tempfile.TemporaryDirectory()
+        cls.test_dir = cls.test_dir_fid.name
+        if not os.path.isdir(cls.test_dir):
+            os.mkdir(cls.test_dir_fid.name)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.test_dir_fid.cleanup()
+
+    def save_data(self, data):
+        for ds in ["train", "valid"]:
+            with open(os.path.join(self.test_dir, f"{ds}.jsonl"), "w") as fid:
+                for l in data:
+                    json.dump(l, fid)
+                    fid.write("\n")
+
+    def test_text(self):
+        data = {"text": "This is an example for the model."}
+        self.save_data(4 * [data])
+        args = types.SimpleNamespace(train=True, test=False, data=self.test_dir)
+        train, valid, test = datasets.load_dataset(args, None)
+        self.assertEqual(len(train), 4)
+        self.assertEqual(len(valid), 4)
+        self.assertEqual(len(test), 0)
+        self.assertTrue(len(train[0]) > 0)
+        self.assertTrue(len(valid[0]) > 0)
+        self.assertTrue(isinstance(train, datasets.Dataset))
+
+    def test_completions(self):
+        data = {"prompt": "What is the capital of France?", "completion": "Paris."}
+        self.save_data(4 * [data])
+        args = types.SimpleNamespace(train=True, test=False, data=self.test_dir)
+        tokenizer = AutoTokenizer.from_pretrained(HF_MODEL_PATH)
+        train, valid, test = datasets.load_dataset(args, tokenizer)
+        self.assertEqual(len(train), 4)
+        self.assertEqual(len(valid), 4)
+        self.assertEqual(len(test), 0)
+        self.assertTrue(len(train[0]) > 0)
+        self.assertTrue(len(valid[0]) > 0)
+        self.assertTrue(isinstance(train, datasets.CompletionsDataset))
+
+    def test_chat(self):
+        data = {
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello."},
+                {"role": "assistant", "content": "How can I assistant you today."},
+            ]
+        }
+        self.save_data(4 * [data])
+        args = types.SimpleNamespace(train=True, test=False, data=self.test_dir)
+        tokenizer = AutoTokenizer.from_pretrained(HF_MODEL_PATH)
+        train, valid, test = datasets.load_dataset(args, tokenizer)
+        self.assertEqual(len(train), 4)
+        self.assertEqual(len(valid), 4)
+        self.assertEqual(len(test), 0)
+        self.assertTrue(len(train[0]) > 0)
+        self.assertTrue(len(valid[0]) > 0)
+        self.assertTrue(isinstance(train, datasets.ChatDataset))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- [x] chat format
- [x] prompt completion pair format
- [x] huggingface chat-templates
- [x] update readme

Supports OpenAI's fine-tuning format. Currently, both methods are supported. The format is as follows:

Chat format:
```
{"messages": [{"role": "system", "content": "Marv is a factual chatbot that is also sarcastic."}, {"role": "user", "content": "What's the capital of France?"}, {"role": "assistant", "content": "Paris, as if everyone doesn't know that already."}]}
{"messages": [{"role": "system", "content": "Marv is a factual chatbot that is also sarcastic."}, {"role": "user", "content": "Who wrote 'Romeo and Juliet'?"}, {"role": "assistant", "content": "Oh, just some guy named William Shakespeare. Ever heard of him?"}]}
{"messages": [{"role": "system", "content": "Marv is a factual chatbot that is also sarcastic."}, {"role": "user", "content": "How far is the Moon from Earth?"}, {"role": "assistant", "content": "Around 384,400 kilometers. Give or take a few, like that really matters."}]}
```

prompt completion pair format：
```
{"prompt": "<prompt text>", "completion": "<ideal generated text>"}
{"prompt": "<prompt text>", "completion": "<ideal generated text>"}
{"prompt": "<prompt text>", "completion": "<ideal generated text>"}
```

For more information see: https://platform.openai.com/docs/guides/fine-tuning/example-format

Also supports  [Chat Templates](https://huggingface.co/blog/chat-templates) .

It is also compatible with current data set formats.

