### PR TITLE
bert encoder inherits from nn.Module now

### DIFF
--- a/bert/model.py
+++ b/bert/model.py
@@ -87,6 +87,7 @@ class TransformerEncoder(nn.Module):
 
 class BertEmbeddings(nn.Module):
     def __init__(self, config: ModelArgs):
+        super().__init__()
         self.word_embeddings = nn.Embedding(config.vocab_size, config.dim)
         self.token_type_embeddings = nn.Embedding(2, config.dim)
         self.position_embeddings = nn.Embedding(
@@ -107,6 +108,7 @@ class BertEmbeddings(nn.Module):
 
 class Bert(nn.Module):
     def __init__(self, config: ModelArgs):
+        super().__init__()
         self.embeddings = BertEmbeddings(config)
         self.encoder = TransformerEncoder(
             num_layers=config.num_hidden_layers,


### PR DESCRIPTION
I was using MLX to do some masked language modeling using bert model example, and I wasn't able to

```optimizer.update(model.trainable_parameters(), grads)```

Like how it is done in the MLP example documentation [here](https://ml-explore.github.io/mlx/build/html/examples/mlp.html)

After adding ```super().__init__()``` to both the ```BERT``` class and the ```BertEmbeddings``` my training loop proceeded.

 
