### PR TITLE
Enable more BERT models

### DIFF
--- a/bert/README.md
+++ b/bert/README.md
@@ -1,6 +1,6 @@
 # BERT
 
-An implementation of BERT [(Devlin, et al., 2019)](https://aclanthology.org/N19-1423/) within MLX.
+An implementation of BERT [(Devlin, et al., 2019)](https://aclanthology.org/N19-1423/) in MLX.
 
 ## Setup 
 
@@ -38,12 +38,12 @@ output, pooled = model(**tokens)
 ```
 
 The `output` contains a `Batch x Tokens x Dims` tensor, representing a vector
-for every input token. If you want to train anything at a **token-level**,
-you'll want to use this.
+for every input token. If you want to train anything at the **token-level**,
+use this.
 
 The `pooled` contains a `Batch x Dims` tensor, which is the pooled
 representation for each input. If you want to train a **classification**
-model, you'll want to use this.
+model, use this.
 
 
 ## Test

--- a/bert/convert.py
+++ b/bert/convert.py
@@ -1,7 +1,7 @@
 import argparse
 
 import numpy
-from transformers import AutoTokenizer, AutoModel
+from transformers import AutoModel
 
 
 

--- a/bert/convert.py
+++ b/bert/convert.py
@@ -1,7 +1,8 @@
 import argparse
 
 import numpy
-from transformers import BertModel
+from transformers import AutoTokenizer, AutoModelForMaskedLM
+
 
 
 def replace_key(key: str) -> str:
@@ -20,26 +21,20 @@ def replace_key(key: str) -> str:
 
 
 def convert(bert_model: str, mlx_model: str) -> None:
-    model = BertModel.from_pretrained(bert_model)
+    model = AutoModelForMaskedLM.from_pretrained(bert_model)
     # save the tensors
     tensors = {
         replace_key(key): tensor.numpy() for key, tensor in model.state_dict().items()
     }
     numpy.savez(mlx_model, **tensors)
 
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Convert BERT weights to MLX.")
     parser.add_argument(
         "--bert-model",
-        choices=[
-            "bert-base-uncased",
-            "bert-base-cased",
-            "bert-large-uncased",
-            "bert-large-cased",
-        ],
+        type=str,
         default="bert-base-uncased",
-        help="The huggingface name of the BERT model to save.",
+        help="The huggingface name of the BERT model to save. Any BERT-like model can be specified.",
     )
     parser.add_argument(
         "--mlx-model",
@@ -48,5 +43,6 @@ if __name__ == "__main__":
         help="The output path for the MLX BERT weights.",
     )
     args = parser.parse_args()
+
 
     convert(args.bert_model, args.mlx_model)

--- a/bert/convert.py
+++ b/bert/convert.py
@@ -1,7 +1,7 @@
 import argparse
 
 import numpy
-from transformers import AutoTokenizer, AutoModelForMaskedLM
+from transformers import AutoTokenizer, AutoModel
 
 
 
@@ -21,7 +21,7 @@ def replace_key(key: str) -> str:
 
 
 def convert(bert_model: str, mlx_model: str) -> None:
-    model = AutoModelForMaskedLM.from_pretrained(bert_model)
+    model = AutoModel.from_pretrained(bert_model)
     # save the tensors
     tensors = {
         replace_key(key): tensor.numpy() for key, tensor in model.state_dict().items()

--- a/bert/convert.py
+++ b/bert/convert.py
@@ -4,7 +4,6 @@ import numpy
 from transformers import AutoModel
 
 
-
 def replace_key(key: str) -> str:
     key = key.replace(".layer.", ".layers.")
     key = key.replace(".self.key.", ".key_proj.")
@@ -28,6 +27,7 @@ def convert(bert_model: str, mlx_model: str) -> None:
     }
     numpy.savez(mlx_model, **tensors)
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Convert BERT weights to MLX.")
     parser.add_argument(
@@ -43,6 +43,5 @@ if __name__ == "__main__":
         help="The output path for the MLX BERT weights.",
     )
     args = parser.parse_args()
-
 
     convert(args.bert_model, args.mlx_model)

--- a/bert/model.py
+++ b/bert/model.py
@@ -64,7 +64,7 @@ class BertEmbeddings(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.word_embeddings = nn.Embedding(config.vocab_size, config.hidden_size)
-        self.token_type_embeddings = nn.Embedding(2, config.hidden_size)
+        self.token_type_embeddings = nn.Embedding(config.type_vocab_size, config.hidden_size)
         self.position_embeddings = nn.Embedding(
             config.max_position_embeddings, config.hidden_size
         )

--- a/bert/test.py
+++ b/bert/test.py
@@ -15,24 +15,43 @@ def run_torch(bert_model: str, batch: List[str]):
     torch_pooled = torch_forward.pooler_output.detach().numpy()
     return torch_output, torch_pooled
 
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Run a BERT-like model for a batch of texts.")
-    parser.add_argument("--bert-model", type=str, default="bert-base-uncased",
-                        help="The model identifier for a BERT-like model from Hugging Face Transformers.")
-    parser.add_argument("--mlx-model", type=str, default="weights/bert-base-uncased.npz",
-                        help="The path of the stored MLX BERT weights (npz file).")
-    parser.add_argument("--text", nargs="+", default=["This is an example of BERT working in MLX."],
-                        help="A batch of texts to process. Multiple texts should be separated by spaces.")
+    parser = argparse.ArgumentParser(
+        description="Run a BERT-like model for a batch of texts."
+    )
+    parser.add_argument(
+        "--bert-model",
+        type=str,
+        default="bert-base-uncased",
+        help="The model identifier for a BERT-like model from Hugging Face Transformers.",
+    )
+    parser.add_argument(
+        "--mlx-model",
+        type=str,
+        default="weights/bert-base-uncased.npz",
+        help="The path of the stored MLX BERT weights (npz file).",
+    )
+    parser.add_argument(
+        "--text",
+        nargs="+",
+        default=["This is an example of BERT working in MLX."],
+        help="A batch of texts to process. Multiple texts should be separated by spaces.",
+    )
 
     args = parser.parse_args()
 
     torch_output, torch_pooled = run_torch(args.bert_model, args.text)
-    
+
     mlx_output, mlx_pooled = model.run(args.bert_model, args.mlx_model, args.text)
 
     if torch_pooled is not None and mlx_pooled is not None:
-        assert np.allclose(torch_output, mlx_output, rtol=1e-4, atol=1e-5), "Model output is different"
-        assert np.allclose(torch_pooled, mlx_pooled, rtol=1e-4, atol=1e-5), "Model pooled output is different"
+        assert np.allclose(
+            torch_output, mlx_output, rtol=1e-4, atol=1e-5
+        ), "Model output is different"
+        assert np.allclose(
+            torch_pooled, mlx_pooled, rtol=1e-4, atol=1e-5
+        ), "Model pooled output is different"
         print("Tests pass :)")
     else:
         print("Pooled outputs were not compared due to one or both being None.")

--- a/bert/test.py
+++ b/bert/test.py
@@ -18,7 +18,7 @@ def run_torch(bert_model: str, batch: List[str]):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Run a BERT-like model for a batch of texts."
+        description="Run a BERT-like model for a batch of text."
     )
     parser.add_argument(
         "--bert-model",

--- a/bert/test.py
+++ b/bert/test.py
@@ -1,3 +1,4 @@
+import argparse
 from typing import List
 
 import model
@@ -14,21 +15,24 @@ def run_torch(bert_model: str, batch: List[str]):
     torch_pooled = torch_forward.pooler_output.detach().numpy()
     return torch_output, torch_pooled
 
-
 if __name__ == "__main__":
-    bert_model = "bert-base-uncased"
-    mlx_model = "weights/bert-base-uncased.npz"
-    batch = [
-        "This is an example of BERT working in MLX.",
-        "A second string",
-        "This is another string.",
-    ]
-    torch_output, torch_pooled = run_torch(bert_model, batch)
-    mlx_output, mlx_pooled = model.run(bert_model, mlx_model, batch)
-    assert np.allclose(
-        torch_output, mlx_output, rtol=1e-4, atol=1e-5
-    ), "Model output is different"
-    assert np.allclose(
-        torch_pooled, mlx_pooled, rtol=1e-4, atol=1e-5
-    ), "Model pooled output is different"
-    print("Tests pass :)")
+    parser = argparse.ArgumentParser(description="Run a BERT-like model for a batch of texts.")
+    parser.add_argument("--bert-model", type=str, default="bert-base-uncased",
+                        help="The model identifier for a BERT-like model from Hugging Face Transformers.")
+    parser.add_argument("--mlx-model", type=str, default="weights/bert-base-uncased.npz",
+                        help="The path of the stored MLX BERT weights (npz file).")
+    parser.add_argument("--text", nargs="+", default=["This is an example of BERT working in MLX."],
+                        help="A batch of texts to process. Multiple texts should be separated by spaces.")
+
+    args = parser.parse_args()
+
+    torch_output, torch_pooled = run_torch(args.bert_model, args.text)
+    
+    mlx_output, mlx_pooled = model.run(args.bert_model, args.mlx_model, args.text)
+
+    if torch_pooled is not None and mlx_pooled is not None:
+        assert np.allclose(torch_output, mlx_output, rtol=1e-4, atol=1e-5), "Model output is different"
+        assert np.allclose(torch_pooled, mlx_pooled, rtol=1e-4, atol=1e-5), "Model pooled output is different"
+        print("Tests pass :)")
+    else:
+        print("Pooled outputs were not compared due to one or both being None.")


### PR DESCRIPTION
I changed some things that were hard coded before that can be retrieved from `config.json` to enable more models with the `BertForMaskedLM` architecture. I tested it with some other models, e.g.

> python convert.py --bert-model "unitary/toxic-bert" --mlx-model weights/toxic-bert.npz    
> python test.py --bert-model "unitary/toxic-bert" --mlx-model "weights/toxic-bert.npz" --text "Hello World!" 

> Tests pass :)

It should in theory also work with RoBERTa models, but I haven't quite gotten it to run yet. 

