### PR TITLE
T5: Fix scaling when embeddings are tied

### DIFF
--- a/t5/t5.py
+++ b/t5/t5.py
@@ -315,9 +315,9 @@ class T5(nn.Module):
             inputs, memory=memory, mask=mask, memory_mask=None, cache=cache
         )
         if not self.tie_word_embeddings:
-            y *= self.model_dim**-0.5
             y = self.lm_head(y)
         else:
+            y *= self.model_dim**-0.5
             y = y @ self.wte.weight.T
         return y, cache
 


### PR DESCRIPTION
As per the [mesh tensorflow](https://github.com/tensorflow/mesh/blob/fa19d69eafc9a482aff0b59ddd96b025c0cb207d/mesh_tensorflow/transformer/transformer.py#L586) and [transformers](https://github.com/huggingface/transformers/blob/00c1d87a7d5c8dfb4554370983b5a3f7c069edd7/src/transformers/models/t5/modeling_t5.py#L1771) implementations, scaling should be done when the embeddings are tied, not the other way round. 