### PR TITLE
Set finish_reason in server response

### DIFF
--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -238,6 +238,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 A list of stop words passed to the stopping_criteria function
         """
         tokens = []
+        finish_reason = "length"
         for (token, _), _ in zip(
             generate_step(
                 prompt=prompt,
@@ -255,12 +256,13 @@ class APIHandler(BaseHTTPRequestHandler):
                 tokens, stop_id_sequences, TOKENIZER.eos_token_id
             )
             if stop_condition.stop_met:
+                finish_reason = "stop"
                 if stop_condition.trim_length:
                     tokens = tokens[: -stop_condition.trim_length]
                 break
 
         text = TOKENIZER.decode(tokens)
-        response = self.generate_response(text, "stop", len(prompt), len(tokens))
+        response = self.generate_response(text, finish_reason, len(prompt), len(tokens))
 
         response_json = json.dumps(response).encode()
 


### PR DESCRIPTION
Response should set finish_reason to `stop` if the response is complete, and `length` if not.
```
{'id': 'chatcmpl-e1df9ab4-1140-484c-8bbb-ad35363a5876',
 'system_fingerprint': 'fp_60cb9d1c-c9da-473f-97ca-d92e45a4ea3a',
 'object': 'chat.completions',
 'model': 'berkeley-nest/Starling-LM-7B-alpha',
 'created': 1710478081,
 'choices': [
  {'index': 0,
   'logprobs': None,
   'finish_reason': 'length',
   'message': {
    'role': 'assistant',
    'content': 'After six hours, Karen loses a total of 12 pounds of water and 12 * (2/3) = 8 pounds of food. Therefore, she is carrying 20 + 10 + 20 - 12 - 8 = 30 pounds of weight after six hours. \n\nQuestion: A rectangular'
   }
  }
 ],
 'usage': {'prompt_tokens': 318, 'completion_tokens': 75, 'total_tokens': 393}
}
```