### PR TITLE
Add mlx-lm version information to HF model card

### DIFF
--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -439,6 +439,7 @@ def upload_to_hub(path: str, upload_repo: str, hf_path: str):
     import os
 
     from huggingface_hub import HfApi, ModelCard, logging
+
     from . import __version__
 
     card = ModelCard.load(hf_path)

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -445,8 +445,8 @@ def upload_to_hub(path: str, upload_repo: str, hf_path: str):
     card.data.tags = ["mlx"] if card.data.tags is None else card.data.tags + ["mlx"]
     card.text = dedent(
         f"""
-            # {upload_repo}
-            This model was converted to MLX format from [`{hf_path}`]() using mlx-lm version **{__version__}**.
+        # {upload_repo}
+        This model was converted to MLX format from [`{hf_path}`]() using mlx-lm version **{__version__}**.
         Refer to the [original model card](https://huggingface.co/{hf_path}) for more details on the model.
         ## Use with mlx
 

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -439,13 +439,14 @@ def upload_to_hub(path: str, upload_repo: str, hf_path: str):
     import os
 
     from huggingface_hub import HfApi, ModelCard, logging
+    from mlx_lm import __version__
 
     card = ModelCard.load(hf_path)
     card.data.tags = ["mlx"] if card.data.tags is None else card.data.tags + ["mlx"]
     card.text = dedent(
         f"""
-        # {upload_repo}
-        This model was converted to MLX format from [`{hf_path}`]().
+            # {upload_repo}
+            This model was converted to MLX format from [`{hf_path}`]() using mlx-lm version **{__version__}**.
         Refer to the [original model card](https://huggingface.co/{hf_path}) for more details on the model.
         ## Use with mlx
 

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -439,7 +439,7 @@ def upload_to_hub(path: str, upload_repo: str, hf_path: str):
     import os
 
     from huggingface_hub import HfApi, ModelCard, logging
-    from mlx_lm import __version__
+    from . import __version__
 
     card = ModelCard.load(hf_path)
     card.data.tags = ["mlx"] if card.data.tags is None else card.data.tags + ["mlx"]


### PR DESCRIPTION
It isn't always clear when HF uploads have been deprecated by subsequent changes to mlx/mlx-lm.  Adding version information to the HF model card can help with this.  