### PR TITLE
Add dropout parameter to lora configuration

### DIFF
--- a/llms/mlx_lm/examples/lora_config.yaml
+++ b/llms/mlx_lm/examples/lora_config.yaml
@@ -59,3 +59,4 @@ lora_parameters:
   rank: 8
   alpha: 16.0
   scale: 10.0
+  dropout: 0.05

--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -265,11 +265,6 @@ def run(args, training_callback: TrainingCallback = None):
 
         print(f"Test loss {test_loss:.3f}, Test ppl {test_ppl:.3f}.")
 
-    if args.prompt is not None:
-        raise NotImplementedError(
-            "Please use mlx_lm.generate with trained adapter for generation."
-        )
-
 
 if __name__ == "__main__":
     parser = build_parser()

--- a/llms/mlx_lm/tuner/utils.py
+++ b/llms/mlx_lm/tuner/utils.py
@@ -32,7 +32,7 @@ def linear_to_lora_layers(
         )
 
     to_lora = lambda lin: LoRALinear.from_linear(
-        lin, r=config["rank"], alpha=config["alpha"], scale=config["scale"]
+        lin, r=config["rank"], alpha=config["alpha"], scale=config["scale"], dropout=config["dropout"]
     )
 
     keys = config.get("keys", None)


### PR DESCRIPTION
A dropout parameter has been added to the lora configuration settings in lora_config.yaml. The LoRALinear class in utils.py has been updated to take this new parameter. Additionally, a AttributeError: 'types.SimpleNamespace' object has no attribute 'prompt' related to `args.prompt` has been removed from lora.py.