### PR TITLE
chore(mlx-lm): fix the top_p implementation.

### DIFF
--- a/llms/mlx_lm/sample_utils.py
+++ b/llms/mlx_lm/sample_utils.py
@@ -1,7 +1,7 @@
 import mlx.core as mx
 
 
-def top_p_filtering(logits: mx.array, top_p: float, temperature: float) -> mx.array:
+def top_p_sampling(logits: mx.array, top_p: float, temperature: float) -> mx.array:
     """
     Apply top-p (nucleus) filtering to logits using cumulative probabilities.
 
@@ -21,8 +21,9 @@ def top_p_filtering(logits: mx.array, top_p: float, temperature: float) -> mx.ar
     probs = mx.softmax(logits / temperature, axis=-1)
 
     # sort probs in ascending order
-    sorted_probs = mx.sort(probs, axis=-1)
     sorted_indices = mx.argsort(probs, axis=-1)
+    sorted_probs = probs[..., sorted_indices]
+
     cumulative_probs = mx.cumsum(sorted_probs, axis=-1)
 
     # select tokens with cumulative probs below threshold

--- a/llms/mlx_lm/sample_utils.py
+++ b/llms/mlx_lm/sample_utils.py
@@ -3,7 +3,7 @@ import mlx.core as mx
 
 def top_p_sampling(logits: mx.array, top_p: float, temperature: float) -> mx.array:
     """
-    Apply top-p (nucleus) filtering to logits using cumulative probabilities.
+    Apply top-p (nucleus) sampling to logits.
 
     Args:
         logits: The logits from the model's output.

--- a/llms/mlx_lm/sample_utils.py
+++ b/llms/mlx_lm/sample_utils.py
@@ -1,0 +1,38 @@
+import mlx.core as mx
+
+
+def top_p_filtering(logits: mx.array, top_p: float, temperature: float) -> mx.array:
+    """
+    Apply top-p (nucleus) filtering to logits using cumulative probabilities.
+
+    Args:
+        logits: The logits from the model's output.
+        top_p: The cumulative probability threshold for top-p filtering.
+        temperature: Temperature parameter for softmax distribution reshaping.
+    Returns:
+        token selected based on the top-p criterion.
+    """
+    if (
+        logits.dtype == mx.bfloat16
+    ):  # workaround for unable to load kernel contiguous_scan_inclusive_sum_bfloat16_bfloat16
+        logits = logits.astype(mx.float32)
+
+    # referenced implementation from https://github.com/huggingface/transformers/blob/main/src/transformers/generation/logits_process.py#L449-L460
+    probs = mx.softmax(logits / temperature, axis=-1)
+
+    # sort probs in ascending order
+    sorted_probs = mx.sort(probs, axis=-1)
+    sorted_indices = mx.argsort(probs, axis=-1)
+    cumulative_probs = mx.cumsum(sorted_probs, axis=-1)
+
+    # select tokens with cumulative probs below threshold
+    top_probs = mx.where(
+        cumulative_probs > 1 - top_p,
+        sorted_probs,
+        mx.zeros_like(sorted_probs),
+    )
+
+    sorted_token = mx.random.categorical(mx.log(top_probs))
+    token = sorted_indices.squeeze(0)[sorted_token]
+
+    return token

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -17,7 +17,7 @@ from huggingface_hub import snapshot_download
 from mlx.utils import tree_flatten
 from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizer
 
-from .sample_utils import top_p_filtering
+from .sample_utils import top_p_sampling
 
 # Local imports
 from .tuner.utils import apply_lora_layers
@@ -146,7 +146,7 @@ def generate_step(
             token = mx.argmax(logits, axis=-1)
         else:
             if top_p > 0 and top_p < 1.0:
-                token = top_p_filtering(logits, top_p, temp)
+                token = top_p_sampling(logits, top_p, temp)
             else:
                 token = mx.random.categorical(logits * (1 / temp))
 

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -145,11 +145,11 @@ def generate_step(
         else:
             # referenced implementation from https://github.com/huggingface/transformers/blob/main/src/transformers/generation/logits_process.py#L449-L460
             if top_p > 0 and top_p < 1.0:
-                # print("top_p", top_p)
                 if (
                     logits.dtype == mx.bfloat16
                 ):  # workdaround for unable to load kernel contiguous_scan_inclusive_sum_bfloat16_bfloat16
                     logits = logits.astype(mx.float32)
+
                 probs = mx.softmax(logits / temp, axis=-1)
 
                 # sort probs in ascending order

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -143,17 +143,21 @@ def generate_step(
         if temp == 0:
             token = mx.argmax(logits, axis=-1)
         else:
+            # referenced implementation from https://github.com/huggingface/transformers/blob/main/src/transformers/generation/logits_process.py#L449-L460
             if top_p > 0 and top_p < 1.0:
+                # print("top_p", top_p)
                 if (
                     logits.dtype == mx.bfloat16
                 ):  # workdaround for unable to load kernel contiguous_scan_inclusive_sum_bfloat16_bfloat16
                     logits = logits.astype(mx.float32)
                 probs = mx.softmax(logits / temp, axis=-1)
 
-                sorted_probs = mx.sort(probs)[::-1]
-                sorted_indices = mx.argsort(probs)[::-1]
+                # sort probs in ascending order
+                sorted_probs = mx.sort(probs, axis=-1)
+                sorted_indices = mx.argsort(probs, axis=-1)
                 cumulative_probs = mx.cumsum(sorted_probs, axis=-1)
 
+                # select tokens with cumulative probs below threshold
                 top_probs = mx.where(
                     cumulative_probs > 1 - top_p,
                     sorted_probs,

--- a/llms/tests/test_sample_utils.py
+++ b/llms/tests/test_sample_utils.py
@@ -2,19 +2,19 @@ import unittest
 from unittest.mock import patch
 
 import mlx.core as mx
-from mlx_lm.sample_utils import top_p_filtering
+from mlx_lm.sample_utils import top_p_sampling
 
 
 class TestLora(unittest.TestCase):
     @patch("mlx.core.random.categorical")
-    def test_top_p_filtering(self, mock_categorical):
+    def test_top_p_sampling(self, mock_categorical):
         logits = mx.array([[1.0, 2.0, 3.0, 4.0]])
         top_p = 0.3
         temperature = 1.0
         expected_token = mx.array([3])
         mock_categorical.return_value = expected_token
 
-        token = top_p_filtering(logits, top_p, temperature)
+        token = top_p_sampling(logits, top_p, temperature)
         expected_top_probs = mx.array([[0.0, 0.0, 0.0, 0.643914]])
         assert mx.allclose(token, expected_token)
         args, _ = mock_categorical.call_args
@@ -26,11 +26,11 @@ class TestLora(unittest.TestCase):
         expected_token = mx.array([3])
         mock_categorical.return_value = expected_token
 
-        token = top_p_filtering(logits, top_p, temperature)
+        token = top_p_sampling(logits, top_p, temperature)
         expected_top_probs = mx.array([[0.0, 0.0871443, 0.236883, 0.643914]])
-        assert mx.allclose(token, expected_token)
+        self.assertTrue(mx.allclose(token, expected_token))
         args, _ = mock_categorical.call_args
-        assert mx.allclose(args[0], mx.log(expected_top_probs))
+        self.assertTrue(mx.allclose(args[0], mx.log(expected_top_probs)))
 
 
 if __name__ == "__main__":

--- a/llms/tests/test_sample_utils.py
+++ b/llms/tests/test_sample_utils.py
@@ -16,9 +16,9 @@ class TestLora(unittest.TestCase):
 
         token = top_p_sampling(logits, top_p, temperature)
         expected_top_probs = mx.array([[0.0, 0.0, 0.0, 0.643914]])
-        assert mx.allclose(token, expected_token)
+        self.assertTrue(mx.allclose(token, expected_token))
         args, _ = mock_categorical.call_args
-        assert mx.allclose(args[0], mx.log(expected_top_probs))
+        self.assertTrue(mx.allclose(args[0], mx.log(expected_top_probs)))
 
         logits = mx.array([[1.0, 2.0, 3.0, 4.0]])
         top_p = 0.9


### PR DESCRIPTION
The top_p is supposed to sort prob in **ascending** order and select the cumulative token prob above the threshold. The current implementation works because we have a bug in reversing the sorted prob, which accidentally makes sorted prob in the correct order. So, it's better to fix the implementation to reduce the confusion.