### PR TITLE
Partially stream de-tokenization

### DIFF
--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -224,6 +224,7 @@ def generate(
 
     tic = time.perf_counter()
     tokens = []
+    token_strings = []
     skip = 0
     REPLACEMENT_CHAR = "\ufffd"
 
@@ -250,19 +251,20 @@ def generate(
             if formatter:
                 formatter(s[skip:], prob.item())
                 skip = len(s)
-            elif REPLACEMENT_CHAR not in s:
+            elif s[-1] != REPLACEMENT_CHAR:
                 print(s[skip:], end="", flush=True)
                 skip = len(s)
-            # Reset token cache
-            if s.endswith("\n"):
+            # Reset token cache at line break
+            if s[-1] == "\n":
                 tokens = []
+                token_strings.append(s)
                 skip = 0
 
     token_count = n + 1
-    token_string = tokenizer.decode(tokens).replace(REPLACEMENT_CHAR, "")
+    token_strings.append(tokenizer.decode(tokens).replace(REPLACEMENT_CHAR, ""))
 
     if verbose:
-        print(token_string[skip:], flush=True)
+        print(token_strings[-1][skip:], flush=True)
         gen_time = time.perf_counter() - tic
         print("=" * 10)
         if token_count == 0:
@@ -273,7 +275,7 @@ def generate(
         print(f"Prompt: {prompt_tps:.3f} tokens-per-sec")
         print(f"Generation: {gen_tps:.3f} tokens-per-sec")
 
-    return token_string
+    return "".join(token_strings)
 
 
 def load_model(model_path: Path, lazy: bool = False) -> nn.Module:

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -253,8 +253,12 @@ def generate(
             elif REPLACEMENT_CHAR not in s:
                 print(s[skip:], end="", flush=True)
                 skip = len(s)
+            # Reset token cache
+            if s.endswith("\n"):
+                tokens = []
+                skip = 0
 
-    token_count = len(tokens)
+    token_count = n + 1
     token_string = tokenizer.decode(tokens).replace(REPLACEMENT_CHAR, "")
 
     if verbose:


### PR DESCRIPTION
Simple heuristic speeds up token generation considerably for long generations. I haven't detected any change in output yet.

On M2 Ultra
```
python -m mlx_lm.generate --model  mlx-community/NeuralBeagle14-7B-4bit-mlx --prompt "Write a quick sort in C++" --max-tokens 500 --temp 0.0
```

Pre: `85.823`
Post: `90.657`
