### PR TITLE
Cast around lora adapters

### DIFF
--- a/llms/mlx_lm/tuner/lora.py
+++ b/llms/mlx_lm/tuner/lora.py
@@ -97,9 +97,6 @@ class LoRALinear(nn.Module):
         self.lora_b = mx.zeros(shape=(r, output_dims))
 
     def __call__(self, x):
-        dtype = self.linear.weight.dtype
-        if isinstance(self.linear, nn.QuantizedLinear):
-            dtype = self.linear.scales.dtype
-        y = self.linear(x.astype(dtype))
+        y = self.linear(x)
         z = (self.dropout(x) @ self.lora_a) @ self.lora_b
-        return y + self.scale * z
+        return y + (self.scale * z).astype(x.dtype)


### PR DESCRIPTION
Should speed up inference with adapters. Since adapters are in fp32 we would up cast at the first LoRA layer and then never downcast which slows things down a lot.

I will report some training runs to be sure there is minimal change there.

Edit: see comment below. Looks like validation loss is unaffected and training speed is noticeably improved 🚀 