### PR TITLE
fix(mlx-lm): missing Lora scale and alpha parameters when loading Lora adapter weights

### DIFF
--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -48,7 +48,7 @@ CONFIG_DEFAULTS = {
     "steps_per_report": 10,
     "steps_per_eval": 200,
     "resume_adapter_file": None,
-    "adapter_file": "adapters.npz",
+    "adapter_file": "adapters.safetensors",
     "save_every": 100,
     "test": False,
     "test_batches": 500,

--- a/llms/mlx_lm/tuner/lora.py
+++ b/llms/mlx_lm/tuner/lora.py
@@ -78,6 +78,13 @@ class LoRALinear(nn.Module):
         bias: bool = False,
     ):
         super().__init__()
+        # store hyperparameters
+        self.lora_config = {
+            "r": r,
+            "alpha": alpha,
+            "dropout": dropout,
+            "scale": scale,
+        }
 
         # Regular linear layer weights
         self.linear = nn.Linear(input_dims, output_dims, bias=bias)
@@ -85,8 +92,7 @@ class LoRALinear(nn.Module):
         self.dropout = nn.Dropout(p=dropout)
 
         # Scale for low-rank update
-        self.scale = mx.array(scale * (alpha / r))
-        self.freeze(keys=["scale"], recurse=False)
+        self.scale = scale * (alpha / r)
 
         # Low rank lora weights
         scale = 1 / math.sqrt(input_dims)

--- a/llms/mlx_lm/tuner/lora.py
+++ b/llms/mlx_lm/tuner/lora.py
@@ -86,6 +86,7 @@ class LoRALinear(nn.Module):
 
         # Scale for low-rank update
         self.scale = mx.array(scale * (alpha / r))
+        self.freeze(keys=["scale"], recurse=False)
 
         # Low rank lora weights
         scale = 1 / math.sqrt(input_dims)

--- a/llms/mlx_lm/tuner/lora.py
+++ b/llms/mlx_lm/tuner/lora.py
@@ -85,7 +85,7 @@ class LoRALinear(nn.Module):
         self.dropout = nn.Dropout(p=dropout)
 
         # Scale for low-rank update
-        self.scale = scale * (alpha / r)
+        self.scale = mx.array(scale * (alpha / r))
 
         # Low rank lora weights
         scale = 1 / math.sqrt(input_dims)

--- a/llms/tests/test_lora.py
+++ b/llms/tests/test_lora.py
@@ -45,7 +45,8 @@ class TestLora(unittest.TestCase):
                 v.size for _, v in tree_flatten(model.trainable_parameters())
             )
             self.assertEqual(
-                trainable_params, lora_layers * params["rank"] * 1024 * 2 * n_keys
+                trainable_params,
+                lora_layers * params["rank"] * 1024 * 2 * n_keys + lora_layers * n_keys,
             )
 
         params = {"rank": 8, "alpha": 16, "dropout": 0.0, "scale": 10.0}

--- a/llms/tests/test_lora.py
+++ b/llms/tests/test_lora.py
@@ -46,7 +46,7 @@ class TestLora(unittest.TestCase):
             )
             self.assertEqual(
                 trainable_params,
-                lora_layers * params["rank"] * 1024 * 2 * n_keys + lora_layers * n_keys,
+                lora_layers * params["rank"] * 1024 * 2 * n_keys,
             )
 
         params = {"rank": 8, "alpha": 16, "dropout": 0.0, "scale": 10.0}


### PR DESCRIPTION
Make the Lora scale as an array value so it can be saved as part of the Lora weight so it can be recovered when loading the Lora weight to lora layer.