### PR TITLE
Kv cache

### DIFF
--- a/llms/mlx_lm/models/base.py
+++ b/llms/mlx_lm/models/base.py
@@ -6,9 +6,9 @@ import mlx.core as mx
 
 class KVCache:
 
-    def __init__(self, length, head_dim, n_kv_heads):
-        self.keys = mx.zeros((1, n_kv_heads, length, head_dim))
-        self.values = mx.zeros((1, n_kv_heads, length, head_dim))
+    def __init__(self, length, head_dim, n_kv_heads, dtype):
+        self.keys = mx.zeros((1, n_kv_heads, length, head_dim), dtype)
+        self.values = mx.zeros((1, n_kv_heads, length, head_dim), dtype)
         self.offset = 0
 
     def update_and_fetch(self, keys, values):

--- a/llms/mlx_lm/models/base.py
+++ b/llms/mlx_lm/models/base.py
@@ -6,17 +6,29 @@ import mlx.core as mx
 
 class KVCache:
 
-    def __init__(self, length, head_dim, n_kv_heads, dtype):
-        self.keys = mx.zeros((1, n_kv_heads, length, head_dim), dtype)
-        self.values = mx.zeros((1, n_kv_heads, length, head_dim), dtype)
+    def __init__(self, head_dim, n_kv_heads):
+        self.n_kv_heads = n_kv_heads
+        self.head_dim = head_dim
+        self.keys = None
+        self.values = None
         self.offset = 0
+        self.step = 256
 
     def update_and_fetch(self, keys, values):
         prev = self.offset
+        if prev % self.step == 0:
+            shape = (1, self.n_kv_heads, max(self.step, keys.shape[2]), self.head_dim)
+            new_k = mx.zeros(shape, keys.dtype)
+            new_v = mx.zeros(shape, values.dtype)
+            if self.keys is not None:
+                self.keys = mx.concatenate([self.keys, new_k], axis=2)
+                self.values = mx.concatenate([self.values, new_v], axis=2)
+            else:
+                self.keys, self.values = new_k, new_v
+
         self.offset += keys.shape[2]
         self.keys[..., prev : self.offset, :] = keys
         self.values[..., prev : self.offset, :] = values
-
         return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
 
 

--- a/llms/mlx_lm/models/base.py
+++ b/llms/mlx_lm/models/base.py
@@ -1,6 +1,24 @@
 import inspect
 from dataclasses import dataclass
 
+import mlx.core as mx
+
+
+class KVCache:
+
+    def __init__(self, length, head_dim, n_kv_heads):
+        self.keys = mx.zeros((1, n_kv_heads, length, head_dim))
+        self.values = mx.zeros((1, n_kv_heads, length, head_dim))
+        self.offset = 0
+
+    def update_and_fetch(self, keys, values):
+        prev = self.offset
+        self.offset += keys.shape[2]
+        self.keys[..., prev : self.offset, :] = keys
+        self.values[..., prev : self.offset, :] = values
+
+        return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+
 
 @dataclass
 class BaseModelArgs:

--- a/llms/mlx_lm/models/base.py
+++ b/llms/mlx_lm/models/base.py
@@ -17,7 +17,8 @@ class KVCache:
     def update_and_fetch(self, keys, values):
         prev = self.offset
         if prev % self.step == 0:
-            shape = (1, self.n_kv_heads, max(self.step, keys.shape[2]), self.head_dim)
+            n_steps = (self.step + keys.shape[2] - 1) // self.step
+            shape = (1, self.n_kv_heads, n_steps * self.step, self.head_dim)
             new_k = mx.zeros(shape, keys.dtype)
             new_v = mx.zeros(shape, values.dtype)
             if self.keys is not None:

--- a/llms/mlx_lm/models/cohere.py
+++ b/llms/mlx_lm/models/cohere.py
@@ -84,11 +84,9 @@ class Attention(nn.Module):
         values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
 
         if cache is not None:
-            key_cache, value_cache = cache
-            queries = self.rope(queries, offset=key_cache.shape[2])
-            keys = self.rope(keys, offset=key_cache.shape[2])
-            keys = mx.concatenate([key_cache, keys], axis=2)
-            values = mx.concatenate([value_cache, values], axis=2)
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
         else:
             queries = self.rope(queries)
             keys = self.rope(keys)
@@ -98,7 +96,7 @@ class Attention(nn.Module):
         )
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-        return self.o_proj(output), (keys, values)
+        return self.o_proj(output)
 
 
 class MLP(nn.Module):
@@ -132,9 +130,9 @@ class TransformerBlock(nn.Module):
         cache: Optional[Tuple[mx.array, mx.array]] = None,
     ) -> mx.array:
         h = self.input_layernorm(x)
-        attn_h, cache = self.self_attn(h, mask, cache)
+        attn_h = self.self_attn(h, mask, cache)
         ff_h = self.mlp(h)
-        return attn_h + ff_h + x, cache
+        return attn_h + ff_h + x
 
 
 class CohereModel(nn.Module):
@@ -167,10 +165,10 @@ class CohereModel(nn.Module):
         if cache is None:
             cache = [None] * len(self.layers)
 
-        for e, layer in enumerate(self.layers):
-            h, cache[e] = layer(h, mask, cache[e])
+        for layer, cache in zip(self.layers, cache):
+            h = layer(h, mask, cache)
 
-        return self.norm(h), cache
+        return self.norm(h)
 
 
 class Model(nn.Module):
@@ -187,7 +185,7 @@ class Model(nn.Module):
         out, cache = self.model(inputs, cache)
         out = self.model.embed_tokens.as_linear(out)
         out = out * self.model.args.logit_scale
-        return out, cache
+        return out
 
     @property
     def layers(self):

--- a/llms/mlx_lm/models/llama.py
+++ b/llms/mlx_lm/models/llama.py
@@ -166,8 +166,8 @@ class LlamaModel(nn.Module):
         if cache is None:
             cache = [None] * len(self.layers)
 
-        for layer, cache in zip(self.layers, cache):
-            h = layer(h, mask, cache=cache)
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, cache=c)
 
         return self.norm(h)
 

--- a/llms/mlx_lm/models/llama.py
+++ b/llms/mlx_lm/models/llama.py
@@ -163,8 +163,11 @@ class LlamaModel(nn.Module):
             )
             mask = mask.astype(h.dtype)
 
-        for e, layer in enumerate(self.layers):
-            h = layer(h, mask, cache=cache[e])
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        for layer, cache in zip(self.layers, cache):
+            h = layer(h, mask, cache=cache)
 
         return self.norm(h)
 

--- a/llms/mlx_lm/models/llama.py
+++ b/llms/mlx_lm/models/llama.py
@@ -78,11 +78,9 @@ class Attention(nn.Module):
         values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
 
         if cache is not None:
-            key_cache, value_cache = cache
-            queries = self.rope(queries, offset=key_cache.shape[2])
-            keys = self.rope(keys, offset=key_cache.shape[2])
-            keys = mx.concatenate([key_cache, keys], axis=2)
-            values = mx.concatenate([value_cache, values], axis=2)
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
         else:
             queries = self.rope(queries)
             keys = self.rope(keys)
@@ -91,7 +89,7 @@ class Attention(nn.Module):
             queries, keys, values, scale=self.scale, mask=mask
         )
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-        return self.o_proj(output), (keys, values)
+        return self.o_proj(output)
 
 
 class MLP(nn.Module):
@@ -124,11 +122,11 @@ class TransformerBlock(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Tuple[mx.array, mx.array]] = None,
     ) -> mx.array:
-        r, cache = self.self_attn(self.input_layernorm(x), mask, cache)
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
         h = x + r
         r = self.mlp(self.post_attention_layernorm(h))
         out = h + r
-        return out, cache
+        return out
 
 
 def create_additive_causal_mask(N: int, offset: int = 0):
@@ -165,13 +163,10 @@ class LlamaModel(nn.Module):
             )
             mask = mask.astype(h.dtype)
 
-        if cache is None:
-            cache = [None] * len(self.layers)
-
         for e, layer in enumerate(self.layers):
-            h, cache[e] = layer(h, mask, cache[e])
+            h = layer(h, mask, cache=cache[e])
 
-        return self.norm(h), cache
+        return self.norm(h)
 
 
 class Model(nn.Module):
@@ -180,14 +175,15 @@ class Model(nn.Module):
         self.model_type = args.model_type
         self.model = LlamaModel(args)
         self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+        self.args = args
 
     def __call__(
         self,
         inputs: mx.array,
         cache=None,
     ):
-        out, cache = self.model(inputs, cache)
-        return self.lm_head(out), cache
+        out = self.model(inputs, cache)
+        return self.lm_head(out)
 
     def sanitize(self, weights):
         # Remove unused precomputed rotary freqs
@@ -198,3 +194,11 @@ class Model(nn.Module):
     @property
     def layers(self):
         return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.hidden_size // self.args.num_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/llms/mlx_lm/models/minicpm.py
+++ b/llms/mlx_lm/models/minicpm.py
@@ -19,7 +19,6 @@ class ModelArgs(BaseModelArgs):
     rms_norm_eps: float
     vocab_size: int
     num_key_value_heads: int
-    max_position_embeddings: int
     scale_depth: float
     scale_emb: float
     rope_theta: float = 1000000.0
@@ -47,7 +46,6 @@ class Attention(nn.Module):
         self.hidden_size = args.hidden_size
         self.num_heads = n_heads = args.num_attention_heads
         self.rope_theta = args.rope_theta
-        self.max_position_embeddings = args.max_position_embeddings
 
         self.head_dim = head_dim = args.hidden_size // n_heads
         self.scale = head_dim**-0.5

--- a/llms/mlx_lm/models/minicpm.py
+++ b/llms/mlx_lm/models/minicpm.py
@@ -96,11 +96,9 @@ class Attention(nn.Module):
         )
 
         if cache is not None:
-            key_cache, value_cache = cache
-            queries = self.rope(queries, offset=key_cache.shape[2])
-            keys = self.rope(keys, offset=key_cache.shape[2])
-            keys = mx.concatenate([key_cache, keys], axis=2)
-            values = mx.concatenate([value_cache, values], axis=2)
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
         else:
             queries = self.rope(queries)
             keys = self.rope(keys)
@@ -111,7 +109,7 @@ class Attention(nn.Module):
 
         attn_output = attn_output.transpose(0, 2, 1, 3).reshape(B, L, -1)
 
-        return self.o_proj(attn_output), (keys, values)
+        return self.o_proj(attn_output)
 
 
 class DecoderLayer(nn.Module):
@@ -137,11 +135,11 @@ class DecoderLayer(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Tuple[mx.array, mx.array]] = None,
     ) -> mx.array:
-        r, cache = self.self_attn(self.input_layernorm(x), mask, cache)
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
         h = x + r * (self.scale_depth / np.sqrt(self.num_hidden_layers))
         r = self.mlp(self.post_attention_layernorm(h))
         out = h + r * (self.scale_depth / np.sqrt(self.num_hidden_layers))
-        return out, cache
+        return out
 
 
 class MiniCPMModel(nn.Module):
@@ -170,10 +168,10 @@ class MiniCPMModel(nn.Module):
         if cache is None:
             cache = [None] * len(self.layers)
 
-        for e, layer in enumerate(self.layers):
-            h, cache[e] = layer(h, mask, cache[e])
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
 
-        return self.norm(h), cache
+        return self.norm(h)
 
 
 class Model(nn.Module):
@@ -191,14 +189,14 @@ class Model(nn.Module):
         inputs: mx.array,
         cache=None,
     ):
-        out, cache = self.model(inputs, cache)
+        out = self.model(inputs, cache)
 
         if not self.args.tie_word_embeddings:
             out = self.lm_head(out / (self.args.hidden_size / self.args.dim_model_base))
         else:
             out = out @ self.model.embed_tokens.weight.T
 
-        return out, cache
+        return out
 
     def sanitize(self, weights):
         if "lm_head.weight" not in weights:
@@ -208,3 +206,11 @@ class Model(nn.Module):
     @property
     def layers(self):
         return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.hidden_size // self.args.num_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/llms/mlx_lm/models/olmo.py
+++ b/llms/mlx_lm/models/olmo.py
@@ -78,11 +78,9 @@ class TransformerBlock(nn.Module):
         values = values.reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
 
         if cache is not None:
-            key_cache, value_cache = cache
-            queries = self.rope(queries, offset=key_cache.shape[2])
-            keys = self.rope(keys, offset=key_cache.shape[2])
-            keys = mx.concatenate([key_cache, keys], axis=2)
-            values = mx.concatenate([value_cache, values], axis=2)
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
         else:
             queries = self.rope(queries)
             keys = self.rope(keys)
@@ -92,7 +90,7 @@ class TransformerBlock(nn.Module):
             scores += mask
         scores = mx.softmax(scores.astype(mx.float32), axis=-1).astype(scores.dtype)
         output = (scores @ values).transpose(0, 2, 1, 3).reshape(B, L, -1)
-        return self.attn_out(output), (keys, values)
+        return self.attn_out(output)
 
     def __call__(
         self,
@@ -100,13 +98,13 @@ class TransformerBlock(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Tuple[mx.array, mx.array]] = None,
     ) -> mx.array:
-        r, cache = self.attend(self.att_norm(x), mask, cache)
+        r = self.attend(self.att_norm(x), mask, cache)
         h = x + r
 
         x1, x2 = mx.split(self.ff_proj(self.ff_norm(h)), 2, axis=-1)
 
         out = h + self.ff_out(nn.silu(x2) * x1)
-        return out, cache
+        return out
 
 
 class Transformer(nn.Module):
@@ -136,15 +134,15 @@ class Transformer(nn.Module):
         if cache is None:
             cache = [None] * len(self.blocks)
 
-        for e, block in enumerate(self.blocks):
-            h, cache[e] = block(h, mask, cache[e])
+        for block, c in zip(self.blocks, cache):
+            h = block(h, mask, c)
 
         h = self.norm(h)
 
         if self.weight_tying:
             return self.wte.as_linear(h), cache
 
-        return self.ff_out(h), cache
+        return self.ff_out(h)
 
 
 class OlmoModel(nn.Module):
@@ -165,6 +163,7 @@ class Model(nn.Module):
         super().__init__()
         self.model_type = args.model_type
         self.model = OlmoModel(args)
+        self.args = args
 
     def __call__(
         self,
@@ -176,3 +175,11 @@ class Model(nn.Module):
     @property
     def layers(self):
         return self.model.transformer.blocks
+
+    @property
+    def head_dim(self):
+        return self.args.d_model // self.args.n_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.args.n_heads

--- a/llms/mlx_lm/models/phi3.py
+++ b/llms/mlx_lm/models/phi3.py
@@ -81,11 +81,9 @@ class Attention(nn.Module):
         values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
 
         if cache is not None:
-            key_cache, value_cache = cache
-            queries = self.rope(queries, offset=key_cache.shape[2])
-            keys = self.rope(keys, offset=key_cache.shape[2])
-            keys = mx.concatenate([key_cache, keys], axis=2)
-            values = mx.concatenate([value_cache, values], axis=2)
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
         else:
             queries = self.rope(queries)
             keys = self.rope(keys)
@@ -94,7 +92,7 @@ class Attention(nn.Module):
             queries, keys, values, scale=self.scale, mask=mask
         )
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-        return self.o_proj(output), (keys, values)
+        return self.o_proj(output)
 
 
 class MLP(nn.Module):
@@ -128,11 +126,11 @@ class TransformerBlock(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Tuple[mx.array, mx.array]] = None,
     ) -> mx.array:
-        r, cache = self.self_attn(self.input_layernorm(x), mask, cache)
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
         h = x + r
         r = self.mlp(self.post_attention_layernorm(h))
         out = h + r
-        return out, cache
+        return out
 
 
 class Phi3Model(nn.Module):
@@ -163,10 +161,10 @@ class Phi3Model(nn.Module):
         if cache is None:
             cache = [None] * len(self.layers)
 
-        for e, layer in enumerate(self.layers):
-            h, cache[e] = layer(h, mask, cache[e])
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
 
-        return self.norm(h), cache
+        return self.norm(h)
 
 
 class Model(nn.Module):
@@ -175,15 +173,24 @@ class Model(nn.Module):
         self.model_type = args.model_type
         self.model = Phi3Model(args)
         self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+        self.args = args
 
     def __call__(
         self,
         inputs: mx.array,
         cache=None,
     ):
-        out, cache = self.model(inputs, cache)
-        return self.lm_head(out), cache
+        out = self.model(inputs, cache)
+        return self.lm_head(out)
 
     @property
     def layers(self):
         return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.hidden_size // self.args.num_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/llms/mlx_lm/models/qwen2.py
+++ b/llms/mlx_lm/models/qwen2.py
@@ -79,11 +79,9 @@ class Attention(nn.Module):
         values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
 
         if cache is not None:
-            key_cache, value_cache = cache
-            queries = self.rope(queries, offset=key_cache.shape[2])
-            keys = self.rope(keys, offset=key_cache.shape[2])
-            keys = mx.concatenate([key_cache, keys], axis=2)
-            values = mx.concatenate([value_cache, values], axis=2)
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
         else:
             queries = self.rope(queries)
             keys = self.rope(keys)
@@ -92,7 +90,7 @@ class Attention(nn.Module):
             queries, keys, values, scale=self.scale, mask=mask
         )
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-        return self.o_proj(output), (keys, values)
+        return self.o_proj(output)
 
 
 class MLP(nn.Module):
@@ -125,11 +123,11 @@ class TransformerBlock(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Tuple[mx.array, mx.array]] = None,
     ) -> mx.array:
-        r, cache = self.self_attn(self.input_layernorm(x), mask, cache)
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
         h = x + r
         r = self.mlp(self.post_attention_layernorm(h))
         out = h + r
-        return out, cache
+        return out
 
 
 class Qwen2Model(nn.Module):
@@ -160,10 +158,10 @@ class Qwen2Model(nn.Module):
         if cache is None:
             cache = [None] * len(self.layers)
 
-        for e, layer in enumerate(self.layers):
-            h, cache[e] = layer(h, mask, cache[e])
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
 
-        return self.norm(h), cache
+        return self.norm(h)
 
 
 class Model(nn.Module):
@@ -180,12 +178,12 @@ class Model(nn.Module):
         inputs: mx.array,
         cache=None,
     ):
-        out, cache = self.model(inputs, cache)
+        out = self.model(inputs, cache)
         if self.args.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(out)
         else:
             out = self.lm_head(out)
-        return out, cache
+        return out
 
     def sanitize(self, weights):
         if self.args.tie_word_embeddings:
@@ -198,3 +196,11 @@ class Model(nn.Module):
     @property
     def layers(self):
         return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.hidden_size // self.args.num_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/llms/mlx_lm/models/qwen2_moe.py
+++ b/llms/mlx_lm/models/qwen2_moe.py
@@ -78,11 +78,9 @@ class Attention(nn.Module):
         values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
 
         if cache is not None:
-            key_cache, value_cache = cache
-            queries = self.rope(queries, offset=key_cache.shape[2])
-            keys = self.rope(keys, offset=key_cache.shape[2])
-            keys = mx.concatenate([key_cache, keys], axis=2)
-            values = mx.concatenate([value_cache, values], axis=2)
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
         else:
             queries = self.rope(queries)
             keys = self.rope(keys)
@@ -91,7 +89,7 @@ class Attention(nn.Module):
             queries, keys, values, scale=self.scale, mask=mask
         )
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-        return self.o_proj(output), (keys, values)
+        return self.o_proj(output)
 
 
 class Qwen2MoeMLP(nn.Module):
@@ -187,11 +185,11 @@ class Qwen2MoeDecoderLayer(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Tuple[mx.array, mx.array]] = None,
     ) -> mx.array:
-        r, cache = self.self_attn(self.input_layernorm(x), mask, cache)
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
         h = x + r
         r = self.mlp(self.post_attention_layernorm(h))
         out = h + r
-        return out, cache
+        return out
 
 
 class Qwen2MoeModel(nn.Module):
@@ -222,10 +220,10 @@ class Qwen2MoeModel(nn.Module):
         if cache is None:
             cache = [None] * len(self.layers)
 
-        for e, layer in enumerate(self.layers):
-            h, cache[e] = layer(h, mask, cache[e])
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
 
-        return self.norm(h), cache
+        return self.norm(h)
 
 
 class Model(nn.Module):
@@ -241,8 +239,8 @@ class Model(nn.Module):
         inputs: mx.array,
         cache=None,
     ):
-        out, cache = self.model(inputs, cache)
-        return self.lm_head(out), cache
+        out = self.model(inputs, cache)
+        return self.lm_head(out)
 
     def sanitize(self, weights):
         if self.args.tie_word_embeddings and "lm_head.weight" not in weights:
@@ -255,3 +253,11 @@ class Model(nn.Module):
     @property
     def layers(self):
         return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.hidden_size // self.args.num_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/llms/mlx_lm/models/stablelm.py
+++ b/llms/mlx_lm/models/stablelm.py
@@ -107,11 +107,9 @@ class Attention(nn.Module):
 
         # Add RoPE to the queries and keys and combine them with the cache
         if cache is not None:
-            key_cache, value_cache = cache
-            queries = self.rope(queries, offset=key_cache.shape[2])
-            keys = self.rope(keys, offset=key_cache.shape[2])
-            keys = mx.concatenate([key_cache, keys], axis=2)
-            values = mx.concatenate([value_cache, values], axis=2)
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
         else:
             queries = self.rope(queries)
             keys = self.rope(keys)
@@ -125,7 +123,7 @@ class Attention(nn.Module):
             queries, keys, values, scale=scale, mask=mask
         ).astype(values.dtype)
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-        return self.o_proj(output), (keys, values)
+        return self.o_proj(output)
 
 
 class MLP(nn.Module):
@@ -157,7 +155,7 @@ class DecoderLayer(nn.Module):
 
     def __call__(self, x, mask, cache):
         h = self.input_layernorm(x)
-        r, cache = self.self_attn(h, mask, cache)
+        r = self.self_attn(h, mask, cache)
 
         if self.use_parallel_residual:
             out = x + r + self.mlp(h)
@@ -165,7 +163,7 @@ class DecoderLayer(nn.Module):
             h = x + r
             r = self.mlp(self.post_attention_layernorm(h))
             out = h + r
-        return out, cache
+        return out
 
 
 class StableLM(nn.Module):
@@ -180,9 +178,10 @@ class StableLM(nn.Module):
         if cache is None:
             cache = [None] * len(self.layers)
 
-        for e, layer in enumerate(self.layers):
-            x, cache[e] = layer(x, mask, cache[e])
-        return self.norm(x), cache
+        for layer, c in zip(self.layers, cache):
+            x = layer(x, mask, cache=c)
+
+        return self.norm(x)
 
 
 class Model(nn.Module):
@@ -191,6 +190,7 @@ class Model(nn.Module):
         self.model_type = config.model_type
         self.model = StableLM(config)
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.args = config
 
     def __call__(
         self,
@@ -203,9 +203,17 @@ class Model(nn.Module):
             mask = nn.MultiHeadAttention.create_additive_causal_mask(x.shape[1])
             mask = mask.astype(x.dtype)
 
-        y, cache = self.model(x, mask, cache)
-        return self.lm_head(y), cache
+        y = self.model(x, mask, cache)
+        return self.lm_head(y)
 
     @property
     def layers(self):
         return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.hidden_size // self.args.num_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/llms/mlx_lm/models/starcoder2.py
+++ b/llms/mlx_lm/models/starcoder2.py
@@ -55,11 +55,9 @@ class Attention(nn.Module):
         values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
 
         if cache is not None:
-            key_cache, value_cache = cache
-            queries = self.rope(queries, offset=key_cache.shape[2])
-            keys = self.rope(keys, offset=key_cache.shape[2])
-            keys = mx.concatenate([key_cache, keys], axis=2)
-            values = mx.concatenate([value_cache, values], axis=2)
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
         else:
             queries = self.rope(queries)
             keys = self.rope(keys)
@@ -69,7 +67,7 @@ class Attention(nn.Module):
         )
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-        return self.o_proj(output), (keys, values)
+        return self.o_proj(output)
 
 
 class MLP(nn.Module):
@@ -102,11 +100,11 @@ class TransformerBlock(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Tuple[mx.array, mx.array]] = None,
     ) -> mx.array:
-        r, cache = self.self_attn(self.input_layernorm(x), mask, cache)
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
         h = x + r
         r = self.mlp(self.post_attention_layernorm(h))
         out = h + r
-        return out, cache
+        return out
 
 
 class Starcoder2Model(nn.Module):
@@ -137,10 +135,10 @@ class Starcoder2Model(nn.Module):
         if cache is None:
             cache = [None] * len(self.layers)
 
-        for e, layer in enumerate(self.layers):
-            h, cache[e] = layer(h, mask, cache[e])
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
 
-        return self.norm(h), cache
+        return self.norm(h)
 
 
 class Model(nn.Module):
@@ -157,13 +155,21 @@ class Model(nn.Module):
         inputs: mx.array,
         cache=None,
     ):
-        out, cache = self.model(inputs, cache)
+        out = self.model(inputs, cache)
         if self.args.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(out)
         else:
             out = self.lm_head(out)
-        return out, cache
+        return out
 
     @property
     def layers(self):
         return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.hidden_size // self.args.num_attention_heads
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads

--- a/llms/mlx_lm/tokenizer_utils.py
+++ b/llms/mlx_lm/tokenizer_utils.py
@@ -314,7 +314,8 @@ def load_tokenizer(model_path, tokenizer_config_extra={}):
 
     tokenizer_file = model_path / "tokenizer.json"
     if tokenizer_file.exists():
-        tokenizer_content = json.load(tokenizer_file.open())
+        with open(tokenizer_file, "r") as fid:
+            tokenizer_content = json.load(fid)
         if "decoder" in tokenizer_content:
             if _is_spm_decoder(tokenizer_content["decoder"]):
                 detokenizer_class = SPMStreamingDetokenizer

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -164,7 +164,7 @@ def generate_step(
 
     y = prompt
     cache = [
-        KVCache(max_tokens, model.head_dim, model.n_kv_heads)
+        KVCache(prompt.size + max_tokens, model.head_dim, model.n_kv_heads)
         for _ in range(len(model.layers))
     ]
     repetition_context = prompt.tolist()

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -114,7 +114,7 @@ def generate_step(
     prompt: mx.array,
     model: nn.Module,
     temp: float = 0.0,
-    max_tokens: int = 1.0,
+    max_tokens: int = 256,
     repetition_penalty: Optional[float] = None,
     repetition_context_size: Optional[int] = 20,
     top_p: float = 1.0,
@@ -127,6 +127,7 @@ def generate_step(
         prompt (mx.array): The input prompt.
         model (nn.Module): The model to use for generation.
         temp (float): The temperature for sampling, if 0 the argmax is used.
+        max_tokens (int): Maximum number of tokens to generate.
         repetition_penalty (float, optional): The penalty factor for repeating tokens.
         repetition_context_size (int, optional): The number of tokens to consider for repetition penalty (default 20).
         top_p (float, optional): Nulceus sampling, higher means model considers more less likely words

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -161,9 +161,13 @@ def generate_step(
         )
 
     y = prompt
-    cache = [
-        KVCache(model.head_dim, model.n_kv_heads) for _ in range(len(model.layers))
-    ]
+    kv_heads = (
+        [model.n_kv_heads] * len(model.layers)
+        if isinstance(model.n_kv_heads, int)
+        else model.n_kv_heads
+    )
+    cache = [KVCache(model.head_dim, n) for n in kv_heads]
+
     repetition_context = prompt.tolist()
 
     if repetition_context_size:

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -164,7 +164,7 @@ def generate_step(
 
     y = prompt
     cache = [
-        KVCache(prompt.size + max_tokens, model.head_dim, model.n_kv_heads)
+        KVCache(prompt.size + max_tokens, model.head_dim, model.n_kv_heads, mx.float16)
         for _ in range(len(model.layers))
     ]
     repetition_context = prompt.tolist()

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -114,7 +114,6 @@ def generate_step(
     prompt: mx.array,
     model: nn.Module,
     temp: float = 0.0,
-    max_tokens: int = 256,
     repetition_penalty: Optional[float] = None,
     repetition_context_size: Optional[int] = 20,
     top_p: float = 1.0,
@@ -127,7 +126,6 @@ def generate_step(
         prompt (mx.array): The input prompt.
         model (nn.Module): The model to use for generation.
         temp (float): The temperature for sampling, if 0 the argmax is used.
-        max_tokens (int): Maximum number of tokens to generate.
         repetition_penalty (float, optional): The penalty factor for repeating tokens.
         repetition_context_size (int, optional): The number of tokens to consider for repetition penalty (default 20).
         top_p (float, optional): Nulceus sampling, higher means model considers more less likely words
@@ -164,8 +162,7 @@ def generate_step(
 
     y = prompt
     cache = [
-        KVCache(prompt.size + max_tokens, model.head_dim, model.n_kv_heads, mx.float16)
-        for _ in range(len(model.layers))
+        KVCache(model.head_dim, model.n_kv_heads) for _ in range(len(model.layers))
     ]
     repetition_context = prompt.tolist()
 
@@ -174,7 +171,7 @@ def generate_step(
 
     def _step(y):
         nonlocal repetition_context
-        logits, cache = model(y[None], cache=cache)
+        logits = model(y[None], cache=cache)
         logits = logits[:, -1, :]
 
         if repetition_penalty:
@@ -248,7 +245,6 @@ def generate(
             prompt_tokens,
             model,
             temp,
-            max_tokens,
             repetition_penalty,
             repetition_context_size,
             top_p,

--- a/llms/mlx_lm/version.py
+++ b/llms/mlx_lm/version.py
@@ -1,3 +1,3 @@
 # Copyright © 2023-2024 Apple Inc.
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/llms/tests/test_models.py
+++ b/llms/tests/test_models.py
@@ -281,14 +281,12 @@ class TestModels(unittest.TestCase):
             vocab_size=10_000,
         )
         model = dbrx.Model(args)
-        self.model_test_runner(
-            model, args.model_type, args.vocab_size, args.num_hidden_layers
-        )
+        self.model_test_runner(model, args.model_type, args.vocab_size, args.n_layers)
 
     def test_minicpm(self):
         from mlx_lm.models import minicpm
 
-        args = dbrx.ModelArgs(
+        args = minicpm.ModelArgs(
             model_type="minicpm",
             hidden_size=1024,
             dim_model_base=1024,


### PR DESCRIPTION
@angeloskath @jagrit06 we should probably land this as its quite helpful for long generations both in terms of speed and memory. Could you take a look at the way I implemented the KV cache? If you are ok with it, I will update the rest of the models and we can merge.

For small generations, the speed difference is negligible:

```
python -m mlx_lm.generate --model mlx-community/NeuralBeagle14-7B-4bit-mlx --prompt "Write a story about Albert Einstein" --temp 0.0 --max-tokens 256
```

KV Cache
```
Prompt: 215.289 tokens-per-sec
Generation: 107.301 tokens-per-sec
```

Original:
```
Prompt: 219.831 tokens-per-sec
Generation: 107.580 tokens-per-sec
```

For large generations or generations with a long prompt, the speed and memory savings are very nice:

Generating 512 tokens with a prompt of length 1125:

KV Cache:
```
Prompt: 1197.379 tokens-per-sec
Generation: 95.258 tokens-per-sec
Cache size (GB): 1.0770343001931906
```

Original:
```
Prompt: 1191.565 tokens-per-sec
Generation: 92.115 tokens-per-sec
Cache size (GB): 12.834949677810073
```

Generating 512 tokens with a prompt of length 2271:

KV Cache:
```
Prompt: 1218.441 tokens-per-sec
Generation: 87.472 tokens-per-sec
Cache size (GB): 2.5441143717616796
```

Original:
```
Prompt: 1217.712 tokens-per-sec
Generation: 79.543 tokens-per-sec
Cache size (GB): 18.396466394886374
```