### PR TITLE
Set mlx version to 0.8.1

### DIFF
--- a/lora/requirements.txt
+++ b/lora/requirements.txt
@@ -1,3 +1,3 @@
-mlx>=0.8.0
+mlx==0.8.1
 transformers
 numpy


### PR DESCRIPTION
The script [lora/lora.py](https://github.com/ml-explore/mlx-examples/blob/main/lora/lora.py) does not seem to work with `mlx` version `0.9.0`.

Forcing it to `0.8.1`, allows training using `lora.py`.
