### PR TITLE
More async eval

### DIFF
--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -188,14 +188,15 @@ def generate_step(
                 repetition_context = repetition_context[-repetition_context_size:]
         return y, prob
 
-    y, prob = _step(y)
+    y, p = _step(y)
 
+    sync = mx.async_eval(y)
     while True:
-        sync = mx.async_eval(y)
-        next_out = _step(y)
+        next_y, next_p = _step(y)
+        next_sync = mx.async_eval(next_y)
         sync.wait()
-        yield y.item(), prob
-        y, prob = next_out
+        yield y.item(), p
+        sync, y, p = next_sync, next_y, next_p
 
 
 def generate(

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -190,13 +190,12 @@ def generate_step(
 
     y, p = _step(y)
 
-    sync = mx.async_eval(y)
+    mx.async_eval(y)
     while True:
         next_y, next_p = _step(y)
-        next_sync = mx.async_eval(next_y)
-        sync.wait()
+        mx.async_eval(next_y)
         yield y.item(), p
-        sync, y, p = next_sync, next_y, next_p
+        y, p = next_y, next_p
 
 
 def generate(


### PR DESCRIPTION
Companion to https://github.com/ml-explore/mlx/pull/998

Benchmarks generating with Gemma on M1 Max:

```
MLX_MAX_OPS_PER_BUFFER=10 python -m mlx_lm.generate --model mlx_model --prompt "Write a story about Einstein" --temp 0.0 --max-tokens 256
```

Pre: `128.018 tokens-per-sec`
Post: `140.112 tokens-per-sec`

Pre + Max Ops 80: `143.687 tokens-per-sec`
Post + Max Ops 80: `164.307 tokens-per-sec`
