### PR TITLE
Removed unused Python imports

### DIFF
--- a/bert/model.py
+++ b/bert/model.py
@@ -1,12 +1,9 @@
 import argparse
-from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
-import numpy
-import numpy as np
 from mlx.utils import tree_unflatten
 from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizerBase
 

--- a/cifar/resnet.py
+++ b/cifar/resnet.py
@@ -3,8 +3,6 @@ Implementation of ResNets for CIFAR-10 as per the original paper [https://arxiv.
 Configurations include ResNet-20, ResNet-32, ResNet-44, ResNet-56, ResNet-110, ResNet-1202.
 """
 
-from typing import Any
-
 import mlx.core as mx
 import mlx.nn as nn
 from mlx.utils import tree_flatten

--- a/clip/model.py
+++ b/clip/model.py
@@ -6,13 +6,12 @@ import logging
 import math
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
 from mlx.core import linalg as LA
 from mlx.nn.losses import cross_entropy
-from mlx.utils import tree_flatten
 
 
 @dataclass

--- a/gcn/main.py
+++ b/gcn/main.py
@@ -5,8 +5,7 @@ from functools import partial
 import mlx.core as mx
 import mlx.nn as nn
 import mlx.optimizers as optim
-from datasets import download_cora, load_data, train_val_test_mask
-from mlx.nn.losses import cross_entropy
+from datasets import load_data, train_val_test_mask
 from mlx.utils import tree_flatten
 
 from gcn import GCN

--- a/llms/gguf_llm/models.py
+++ b/llms/gguf_llm/models.py
@@ -6,10 +6,8 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import mlx.core as mx
 import mlx.nn as nn
-import numpy as np
 import utils
 from huggingface_hub import snapshot_download
-from mlx.utils import tree_flatten, tree_unflatten
 
 
 @dataclass

--- a/llms/mixtral/mixtral.py
+++ b/llms/mixtral/mixtral.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx.utils import tree_map, tree_unflatten
+from mlx.utils import tree_unflatten
 from sentencepiece import SentencePieceProcessor
 
 

--- a/llms/mlx_lm/models/dbrx.py
+++ b/llms/mlx_lm/models/dbrx.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple, Union
+from typing import Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn

--- a/llms/mlx_lm/tuner/trainer.py
+++ b/llms/mlx_lm/tuner/trainer.py
@@ -2,7 +2,6 @@
 
 import time
 from dataclasses import dataclass, field
-from functools import partial
 from pathlib import Path
 from typing import Union
 

--- a/llms/speculative_decoding/decoder.py
+++ b/llms/speculative_decoding/decoder.py
@@ -1,9 +1,6 @@
-from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List
 
 import mlx.core as mx
-import mlx.nn as nn
-import numpy as np
 import transformers
 from model import Model
 

--- a/llms/speculative_decoding/main.py
+++ b/llms/speculative_decoding/main.py
@@ -1,11 +1,7 @@
 import argparse
-import glob
-import json
 import time
-from pathlib import Path
 
 import mlx.core as mx
-import mlx.nn as nn
 from decoder import SpeculativeDecoder
 from mlx.utils import tree_unflatten
 from model import Model

--- a/llms/speculative_decoding/model.py
+++ b/llms/speculative_decoding/model.py
@@ -3,8 +3,8 @@ from typing import List, Optional, Tuple
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
-from mlx.utils import tree_map, tree_unflatten
-from transformers import AutoTokenizer, T5Config
+from mlx.utils import tree_map
+from transformers import T5Config
 
 
 def _relative_position_bucket(

--- a/llms/tests/test_lora.py
+++ b/llms/tests/test_lora.py
@@ -10,7 +10,6 @@ import mlx.nn as nn
 import mlx.optimizers as opt
 from mlx.utils import tree_flatten
 from mlx_lm import lora, tuner
-from mlx_lm.lora import yaml_loader
 from mlx_lm.tuner.lora import LoRALinear
 from mlx_lm.tuner.utils import build_schedule
 

--- a/lora/lora.py
+++ b/lora/lora.py
@@ -11,7 +11,7 @@ import mlx.nn as nn
 import mlx.optimizers as optim
 import numpy as np
 import utils as lora_utils
-from mlx.utils import tree_flatten, tree_unflatten
+from mlx.utils import tree_flatten
 from models import LoRALinear
 
 

--- a/lora/models.py
+++ b/lora/models.py
@@ -1,6 +1,5 @@
 # Copyright © 2023 Apple Inc.
 
-import glob
 import inspect
 import math
 from dataclasses import dataclass
@@ -8,7 +7,6 @@ from typing import Dict, Optional, Tuple, Union
 
 import mlx.core as mx
 import mlx.nn as nn
-import numpy as np
 
 
 @dataclass

--- a/speechcommands/kwt.py
+++ b/speechcommands/kwt.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import mlx.core as mx
 import mlx.nn as nn
 from mlx.utils import tree_flatten

--- a/speechcommands/main.py
+++ b/speechcommands/main.py
@@ -4,7 +4,6 @@ from functools import partial
 
 import kwt
 import mlx.core as mx
-import mlx.data as dx
 import mlx.nn as nn
 import mlx.optimizers as optim
 from mlx.data.datasets import load_speechcommands

--- a/stable_diffusion/stable_diffusion/model_io.py
+++ b/stable_diffusion/stable_diffusion/model_io.py
@@ -1,7 +1,6 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import json
-from functools import partial
 from typing import Optional
 
 import mlx.core as mx

--- a/whisper/benchmark.py
+++ b/whisper/benchmark.py
@@ -2,7 +2,6 @@
 import argparse
 import os
 import subprocess
-import sys
 import time
 
 import mlx.core as mx

--- a/whisper/test.py
+++ b/whisper/test.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import subprocess
 import unittest
 from dataclasses import asdict
 from pathlib import Path

--- a/whisper/whisper/audio.py
+++ b/whisper/whisper/audio.py
@@ -3,7 +3,7 @@
 import os
 from functools import lru_cache
 from subprocess import CalledProcessError, run
-from typing import Optional, Union
+from typing import Union
 
 import mlx.core as mx
 import numpy as np

--- a/whisper/whisper/decoding.py
+++ b/whisper/whisper/decoding.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field, replace
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import mlx.core as mx
-import mlx.nn as nn
 import numpy as np
 from mlx.utils import tree_map
 


### PR DESCRIPTION
- Removed unused Python imports in the following files (example format: **file_name:line_number imported_pkg**):
  - bert/model.py:10: tree_unflatten
  - bert/model.py:2: dataclass
  - bert/model.py:8: numpy
  - cifar/resnet.py:6: Any
  - clip/model.py:15: tree_flatten
  - clip/model.py:9: Union
  - gcn/main.py:8: download_cora
  - gcn/main.py:9: cross_entropy
  - llms/gguf_llm/models.py:12: tree_flatten, tree_unflatten
  - llms/gguf_llm/models.py:9: numpy
  - llms/mixtral/mixtral.py:12: tree_map
  - llms/mlx_lm/models/dbrx.py:2: Dict, Union
  - llms/mlx_lm/tuner/trainer.py:5: partial
  - llms/speculative_decoding/decoder.py:1: dataclass, field
  - llms/speculative_decoding/decoder.py:2: Optional
  - llms/speculative_decoding/decoder.py:5: mlx.nn
  - llms/speculative_decoding/decoder.py:6: numpy
  - llms/speculative_decoding/main.py:2: glob
  - llms/speculative_decoding/main.py:3: json
  - llms/speculative_decoding/main.py:5: Path
  - llms/speculative_decoding/main.py:8: mlx.nn
  - llms/speculative_decoding/model.py:6: tree_unflatten
  - llms/speculative_decoding/model.py:7: AutoTokenizer
  - llms/tests/test_lora.py:13: yaml_loader
  - lora/lora.py:14: tree_unflatten
  - lora/models.py:11: numpy
  - lora/models.py:3: glob
  - speechcommands/kwt.py:1: Any
  - speechcommands/main.py:7: mlx.data
  - stable_diffusion/stable_diffusion/model_io.py:4: partial
  - whisper/benchmark.py:5: sys
  - whisper/test.py:5: subprocess
  - whisper/whisper/audio.py:6: Optional
  - whisper/whisper/decoding.py:8: mlx.nn