### PR TITLE
Add multi_commits to uploads

### DIFF
--- a/llms/mlx_lm/convert.py
+++ b/llms/mlx_lm/convert.py
@@ -43,6 +43,12 @@ def configure_parser() -> argparse.ArgumentParser:
         default=None,
     )
     parser.add_argument(
+        "--upload-multi-commits",
+        help="Use multiple commits to upload the model, which allows for resuming.",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
         "-d",
         "--dequantize",
         help="Dequantize a quantized model.",

--- a/llms/mlx_lm/fuse.py
+++ b/llms/mlx_lm/fuse.py
@@ -63,6 +63,12 @@ def parse_arguments() -> argparse.Namespace:
         default="ggml-model-f16.gguf",
         type=str,
     )
+    parser.add_argument(
+        "--upload-multi-commits",
+        help="Use multiple commits to upload the model, which allows for resuming.",
+        action="store_true",
+        default=False,
+    )
     return parser.parse_args()
 
 
@@ -121,7 +127,9 @@ def main() -> None:
             raise ValueError(
                 "Must provide original Hugging Face repo to upload local model."
             )
-        upload_to_hub(args.save_path, args.upload_repo, hf_path)
+        upload_to_hub(
+            args.save_path, args.upload_repo, hf_path, args.upload_multi_commits
+        )
 
 
 if __name__ == "__main__":

--- a/llms/mlx_lm/merge.py
+++ b/llms/mlx_lm/merge.py
@@ -43,6 +43,12 @@ def configure_parser() -> argparse.ArgumentParser:
         type=str,
         default=None,
     )
+    parser.add_argument(
+        "--upload-multi-commits",
+        help="Use multiple commits to upload the model, which allows for resuming.",
+        action="store_true",
+        default=False,
+    )
     return parser
 
 
@@ -116,6 +122,7 @@ def merge(
     config: str,
     mlx_path: str = "mlx_model",
     upload_repo: Optional[str] = None,
+    upload_multi_commits: Optional[bool] = None,
 ):
     with open(config, "r") as fid:
         merge_conf = yaml.safe_load(fid)
@@ -159,7 +166,7 @@ def merge(
     save_config(config, config_path=mlx_path / "config.json")
 
     if upload_repo is not None:
-        upload_to_hub(mlx_path, upload_repo, base_hf_path)
+        upload_to_hub(mlx_path, upload_repo, base_hf_path, upload_multi_commits)
 
 
 def main():

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -425,7 +425,7 @@ def make_shards(weights: dict, max_file_size_gb: int = MAX_FILE_SIZE_GB) -> list
     return shards
 
 
-def upload_to_hub(path: str, upload_repo: str, hf_path: str):
+def upload_to_hub(path: str, upload_repo: str, hf_path: str, multi_commits: bool=False):
     """
     Uploads the model to Hugging Face hub.
 
@@ -471,6 +471,8 @@ def upload_to_hub(path: str, upload_repo: str, hf_path: str):
         folder_path=path,
         repo_id=upload_repo,
         repo_type="model",
+        multi_commits=multi_commits,
+        multi_commits_verbose=multi_commits,
     )
     print(f"Upload successful, go to https://huggingface.co/{upload_repo} for details.")
 
@@ -584,6 +586,7 @@ def convert(
     q_bits: int = 4,
     dtype: str = "float16",
     upload_repo: str = None,
+    upload_multi_commits: Optional[bool] = None,
     revision: Optional[str] = None,
     dequantize: bool = False,
 ):
@@ -623,4 +626,4 @@ def convert(
     save_config(config, config_path=mlx_path / "config.json")
 
     if upload_repo is not None:
-        upload_to_hub(mlx_path, upload_repo, hf_path)
+        upload_to_hub(mlx_path, upload_repo, hf_path, upload_multi_commits)

--- a/lora/convert.py
+++ b/lora/convert.py
@@ -82,6 +82,12 @@ if __name__ == "__main__":
         type=str,
         default=None,
     )
+    parser.add_argument(
+        "--upload-multi-commits",
+        help="Use multiple commits to upload the model, which allows for resuming.",
+        action="store_true",
+        default=False,
+    )
 
     args = parser.parse_args()
 
@@ -96,4 +102,6 @@ if __name__ == "__main__":
 
     utils.save_model(args.mlx_path, weights, tokenizer, config)
     if args.upload_name is not None:
-        utils.upload_to_hub(args.mlx_path, args.upload_name, args.hf_path)
+        utils.upload_to_hub(
+            args.mlx_path, args.upload_name, args.hf_path, args.upload_multi_commits
+        )

--- a/lora/fuse.py
+++ b/lora/fuse.py
@@ -43,6 +43,12 @@ if __name__ == "__main__":
         default=None,
     )
     parser.add_argument(
+        "--upload-multi-commits",
+        help="Use multiple commits to upload the model, which allows for resuming.",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
         "-d",
         "--de-quantize",
         help="Generate a de-quantized model.",
@@ -111,4 +117,6 @@ if __name__ == "__main__":
             raise ValueError(
                 "Must provide original Hugging Face repo to upload local model."
             )
-        utils.upload_to_hub(args.save_path, args.upload_name, hf_path)
+        utils.upload_to_hub(
+            args.save_path, args.upload_name, hf_path, args.upload_multi_commits
+        )

--- a/lora/utils.py
+++ b/lora/utils.py
@@ -33,7 +33,7 @@ def fetch_from_hub(hf_path: str):
     return weights, config.to_dict(), tokenizer
 
 
-def upload_to_hub(path: str, name: str, hf_path: str):
+def upload_to_hub(path: str, name: str, hf_path: str, multi_commits: bool=False):
     import os
 
     from huggingface_hub import HfApi, ModelCard, logging
@@ -64,6 +64,8 @@ python generate.py --model {repo_id} --prompt "My name is"
         folder_path=path,
         repo_id=repo_id,
         repo_type="model",
+        multi_commits=multi_commits,
+        multi_commits_verbose=multi_commits,
     )
 
 


### PR DESCRIPTION
This PR adds an optional flag `--upload-multi-commits` to use an experimental feature in the HuggingFace API that creates multiple commits per upload. It is very convenient for big models with multiple files. It also allows for resuming the upload if something fails by simply re-running the command. I've tested it with `convert`, it looks [like this](https://huggingface.co/mlx-community/zephyr-orpo-141b-A35b-v0.1-8bit/discussions/2).