### PR TITLE
fix(mlx-lm): unicode decoding in server.py

### DIFF
--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -336,7 +336,6 @@ class APIHandler(BaseHTTPRequestHandler):
                     )
                 break
 
-            detokenizer.finalize()
             new_text = detokenizer.last_segment
             response = self.generate_response(new_text, None)
             self.wfile.write(f"data: {json.dumps(response)}\n\n".encode())
@@ -345,7 +344,6 @@ class APIHandler(BaseHTTPRequestHandler):
 
         # check is there any remaining text to send
         if stop_sequence_buffer:
-            detokenizer.finalize()
             next_chunk = (
                 detokenizer.last_segment
                 if stop_sequence_suffix is None


### PR DESCRIPTION
I misunderstood how the new detokenizer works, didn't realize that detokenizer.finalize() would force decoding of the current token, which breaks the unicode decoding that requires more than 1 token.
before:
<img width="1270" alt="image" src="https://github.com/ml-explore/mlx-examples/assets/7523197/c363cc19-286e-4cb0-aabc-025c9c276c81">
after:
<img width="514" alt="image" src="https://github.com/ml-explore/mlx-examples/assets/7523197/d9295850-ddf1-44b3-b63b-1007fa1b3a4d">
