### PR TITLE
Load fused model with transformers

### DIFF
--- a/lora/fuse.py
+++ b/lora/fuse.py
@@ -48,11 +48,6 @@ if __name__ == "__main__":
         help="Generate a de-quantized model.",
         action="store_true",
     )
-    parser.add_argument(
-        "--save-format",
-        help="Format for saved safetensors. Examples: 'mlx', 'pt', 'tf', 'flax'.",
-        default="mlx",
-    )   
 
     print("Loading pretrained model")
     args = parser.parse_args()
@@ -105,7 +100,7 @@ if __name__ == "__main__":
     weights = dict(tree_flatten(model.parameters()))
     if args.de_quantize:
         config.pop("quantization", None)
-    utils.save_model(args.save_path, weights, tokenizer, config, args.save_format)
+    utils.save_model(args.save_path, weights, tokenizer, config)
 
     if args.upload_name is not None:
         hf_path = args.hf_path

--- a/lora/fuse.py
+++ b/lora/fuse.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--upload-name",
-        help="The name of model to upload to Hugging Face MLX Community",
+        help="The name of model to upload to Hugging Face MLX Community.",
         type=str,
         default=None,
     )
@@ -48,6 +48,11 @@ if __name__ == "__main__":
         help="Generate a de-quantized model.",
         action="store_true",
     )
+    parser.add_argument(
+        "--save-format",
+        help="Format for saved safetensors. Examples: 'mlx', 'pt', 'tf', 'flax'.",
+        default="mlx",
+    )   
 
     print("Loading pretrained model")
     args = parser.parse_args()
@@ -100,7 +105,7 @@ if __name__ == "__main__":
     weights = dict(tree_flatten(model.parameters()))
     if args.de_quantize:
         config.pop("quantization", None)
-    utils.save_model(args.save_path, weights, tokenizer, config)
+    utils.save_model(args.save_path, weights, tokenizer, config, args.save_format)
 
     if args.upload_name is not None:
         hf_path = args.hf_path

--- a/lora/utils.py
+++ b/lora/utils.py
@@ -81,7 +81,7 @@ def make_shards(weights: dict, max_file_size_gibibyte: int = 15):
     return shards
 
 
-def save_model(save_dir: str, weights, tokenizer, config):
+def save_model(save_dir: str, weights, tokenizer, config, fused_format):
     save_dir = Path(save_dir)
     save_dir.mkdir(parents=True, exist_ok=True)
 
@@ -93,14 +93,29 @@ def save_model(save_dir: str, weights, tokenizer, config):
         else "model.safetensors"
     )
 
+    total_size = sum(v.nbytes for v in weights.values())
+    index_data = {"metadata": {"total_size": total_size}, "weight_map": {}}
+
     for i, shard in enumerate(shards):
         shard_name = shard_file_format.format(i + 1, shards_count)
-        mx.save_safetensors(str(save_dir / shard_name), shard)
+        mx.save_safetensors(str(save_dir / shard_name), shard, metadata={"format": fused_format})
+        for weight_name in shard.keys():
+            index_data["weight_map"][weight_name] = shard_name
+        del shard
 
     tokenizer.save_pretrained(save_dir)
-
     with open(save_dir / "config.json", "w") as fid:
         json.dump(config, fid, indent=4)
+
+    index_data["weight_map"] = {
+        k: index_data["weight_map"][k] for k in sorted(index_data["weight_map"])
+    }
+    with open(save_dir / "model.safetensors.index.json", "w") as f:
+        json.dump(
+            index_data,
+            f,
+            indent=4,
+        )
 
 
 def load(path_or_hf_repo: str):

--- a/lora/utils.py
+++ b/lora/utils.py
@@ -98,7 +98,9 @@ def save_model(save_dir: str, weights, tokenizer, config):
 
     for i, shard in enumerate(shards):
         shard_name = shard_file_format.format(i + 1, shards_count)
-        mx.save_safetensors(str(save_dir / shard_name), shard, metadata={"format": "mlx"})
+        mx.save_safetensors(
+            str(save_dir / shard_name), shard, metadata={"format": "mlx"}
+        )
         for weight_name in shard.keys():
             index_data["weight_map"][weight_name] = shard_name
         del shard

--- a/lora/utils.py
+++ b/lora/utils.py
@@ -81,7 +81,7 @@ def make_shards(weights: dict, max_file_size_gibibyte: int = 15):
     return shards
 
 
-def save_model(save_dir: str, weights, tokenizer, config, fused_format):
+def save_model(save_dir: str, weights, tokenizer, config):
     save_dir = Path(save_dir)
     save_dir.mkdir(parents=True, exist_ok=True)
 
@@ -98,7 +98,7 @@ def save_model(save_dir: str, weights, tokenizer, config, fused_format):
 
     for i, shard in enumerate(shards):
         shard_name = shard_file_format.format(i + 1, shards_count)
-        mx.save_safetensors(str(save_dir / shard_name), shard, metadata={"format": fused_format})
+        mx.save_safetensors(str(save_dir / shard_name), shard, metadata={"format": "mlx"})
         for weight_name in shard.keys():
             index_data["weight_map"][weight_name] = shard_name
         del shard


### PR DESCRIPTION
Was unable to load the fused model on an ubuntu environment. Was able to load it when I changed save_safetensors metadata to 'pt' (there was a related [GH](https://github.com/ml-explore/mlx/issues/633) issue I believe) and produced model.safetensors.index.json. If this patch is not optimal, would still be better imo to let users know about this incompatibility, until it's fixed.