### PR TITLE
Use CORS headers for streaming for MLX Server

### DIFF
--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -82,17 +82,21 @@ class APIHandler(BaseHTTPRequestHandler):
         self.created = int(time.time())
         super().__init__(*args, **kwargs)
 
-    def _set_completion_headers(self, status_code: int = 200):
-        self.send_response(status_code)
-        self.send_header("Content-type", "application/json")
+    def _set_cors_headers(self):
         self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header("Access-Control-Allow-Methods", "*")
         self.send_header("Access-Control-Allow-Headers", "*")
+
+    def _set_completion_headers(self, status_code: int = 200):
+        self.send_response(status_code)
+        self.send_header("Content-type", "application/json")
+        self._set_cors_headers()
 
     def _set_stream_headers(self, status_code: int = 200):
         self.send_response(status_code)
         self.send_header("Content-type", "text/event-stream")
         self.send_header("Cache-Control", "no-cache")
+        self._set_cors_headers()
 
     def do_OPTIONS(self):
         self._set_completion_headers(204)


### PR DESCRIPTION
Hello, folks! 👋🏼 

I noticed that cross-origin resource sharing (CORS) is not enabled when using the streaming endpoint, but it is enabled when using the non-streaming request path.

- Makes local language models more accessible for people who are building purely front-end web clients.
- Eliminates the need for server-side proxying of responses from MLX Server, which can reduce streaming latency by removing intermediaries.

### Changes

This change creates a common "private" method `_set_cors_headers(self)` to allow both `_set_completion_headers` and `_set_stream_headers` to use CORS without duplicating code.

### Better Compatibility with OpenAI JavaScript Client

It will also be compatible with OpenAI's JavaScript client in the browser:

```javascript
const openai = new OpenAI({
  baseURL: "http://localhost:8080/v1",
  apiKey: 'not-needed',
  dangerouslyAllowBrowser: true,
  // ^ this is not really dangerous for a locally hosted model as there's no API key!
});

const stream = await openai.chat.completions.create({
  messages: [
    { "role": "user", "content": "Write a poem about dogs." }
  ],
  temperature: 0.1,
  stream: true,
});

for await (const chunk of stream) {
  console.log(chunk)
}
```