### PR TITLE
Add Supported Quantized Phi-3-mini-4k-instruct gguf Weight

### DIFF
--- a/llms/gguf_llm/README.md
+++ b/llms/gguf_llm/README.md
@@ -47,6 +47,10 @@ Models that have been tested and work include:
 - [TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF](https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF),
   for quantized models use:
   - `tinyllama-1.1b-chat-v1.0.Q8_0.gguf`
-  - `tinyllama-1.1b-chat-v1.0.Q4_0.gguf` 
+  - `tinyllama-1.1b-chat-v1.0.Q4_0.gguf`
+
+- [Jaward/phi-3-mini-4k-instruct.Q4_0.gguf](https://huggingface.co/Jaward/phi-3-mini-4k-instruct.Q4_0.gguf),
+  for 4 bits quantized phi-3-mini-4k-instruct use:
+  - `phi-3-mini-4k-instruct.Q4_0.gguf` 
 
 [^1]: For more information on GGUF see [the documentation](https://github.com/ggerganov/ggml/blob/master/docs/gguf.md).

--- a/llms/gguf_llm/models.py
+++ b/llms/gguf_llm/models.py
@@ -18,6 +18,7 @@ class ModelArgs:
     num_attention_heads: int
     rms_norm_eps: float
     vocab_size: int
+    context_length: int
     num_key_value_heads: int = None
     rope_theta: float = 10000
     rope_traditional: bool = False
@@ -157,6 +158,20 @@ class LlamaModel(nn.Module):
             TransformerBlock(args=args) for _ in range(args.num_hidden_layers)
         ]
         self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        # model info
+        print(
+            f"Model info\n"
+            f"==========\n"
+            f"Context length: {args.context_length}\n"
+            f"Hidden size: {args.hidden_size}\n"
+            f"Num layers: {args.num_hidden_layers}\n"
+            f"Num attention heads: {args.num_attention_heads}\n"
+            f"Num key value heads: {args.num_key_value_heads}\n"
+            f"RMSNorm epsilon: {args.rms_norm_eps}\n"
+            f"Vocab size: {args.vocab_size}\n"
+            f"RoPE theta: {args.rope_theta}\n"
+            f"RoPE traditional: {args.rope_traditional}\n"
+        )
 
     def __call__(
         self,
@@ -196,6 +211,7 @@ class Model(nn.Module):
 
 def get_config(metadata: dict):
     output = {
+        "context_length": metadata["llama.context_length"],
         "hidden_size": metadata["llama.embedding_length"],
         "num_hidden_layers": metadata["llama.block_count"],
         "num_attention_heads": metadata["llama.attention.head_count"],
@@ -265,13 +281,17 @@ def load(gguf_file: str, repo: str = None):
     if gguf_ft == 0 or gguf_ft == 1:
         # ALL_F32 or MOSTLY_F16
         quantization = None
+        print("Non-quantized Float32 model")
         pass
     elif gguf_ft == 2 or gguf_ft == 3:
         # MOSTLY_Q4_0 or MOSTLY_Q4_1
         quantization = {"group_size": 32, "bits": 4}
+        # print bits value
+        print(f"{quantization['bits']} bits quantized model")
     elif gguf_ft == 7:
         # MOSTLY_Q8_0 = 7
         quantization = {"group_size": 32, "bits": 8}
+        print(f"{quantization['bits']} bits quantized model")
     else:
         quantization = None
         print("[WARNING] Using unsupported GGUF quantization. Casting to float16.")

--- a/llms/gguf_llm/models.py
+++ b/llms/gguf_llm/models.py
@@ -277,7 +277,7 @@ def load(gguf_file: str, repo: str = None):
     if gguf_ft == 0 or gguf_ft == 1:
         # ALL_F32 or MOSTLY_F16
         quantization = None
-        print("Non-quantized Float32 model")
+        print("Non-quantized: float16 or float32 model")
         pass
     elif gguf_ft == 2 or gguf_ft == 3:
         # MOSTLY_Q4_0 or MOSTLY_Q4_1

--- a/llms/gguf_llm/models.py
+++ b/llms/gguf_llm/models.py
@@ -163,14 +163,10 @@ class LlamaModel(nn.Module):
             f"Model info\n"
             f"==========\n"
             f"Context length: {args.context_length}\n"
+            f"Vocab size: {args.vocab_size}\n"
             f"Hidden size: {args.hidden_size}\n"
             f"Num layers: {args.num_hidden_layers}\n"
             f"Num attention heads: {args.num_attention_heads}\n"
-            f"Num key value heads: {args.num_key_value_heads}\n"
-            f"RMSNorm epsilon: {args.rms_norm_eps}\n"
-            f"Vocab size: {args.vocab_size}\n"
-            f"RoPE theta: {args.rope_theta}\n"
-            f"RoPE traditional: {args.rope_traditional}\n"
         )
 
     def __call__(

--- a/llms/gguf_llm/models.py
+++ b/llms/gguf_llm/models.py
@@ -277,7 +277,7 @@ def load(gguf_file: str, repo: str = None):
     if gguf_ft == 0 or gguf_ft == 1:
         # ALL_F32 or MOSTLY_F16
         quantization = None
-        print("Non-quantized: float16 or float32 model")
+        print("Unsupported gguf quantization: float16 or float32 quantized model")
         pass
     elif gguf_ft == 2 or gguf_ft == 3:
         # MOSTLY_Q4_0 or MOSTLY_Q4_1

--- a/llms/gguf_llm/models.py
+++ b/llms/gguf_llm/models.py
@@ -277,7 +277,6 @@ def load(gguf_file: str, repo: str = None):
     if gguf_ft == 0 or gguf_ft == 1:
         # ALL_F32 or MOSTLY_F16
         quantization = None
-        print("Unsupported gguf quantization: float16 or float32 quantized model")
         pass
     elif gguf_ft == 2 or gguf_ft == 3:
         # MOSTLY_Q4_0 or MOSTLY_Q4_1


### PR DESCRIPTION
The official phi-3-mini-4k-instruct gguf weight is currently unsupported (of type array(15, dtype=uint32)) by mlx, I uploaded a supported 4bit quantized gguf weight, download here: https://huggingface.co/Jaward/phi-3-mini-4k-instruct.Q4_0.gguf.

Also included a print of model info and quant type.

<img width="1111" alt="Screenshot 2024-04-24 at 13 47 35" src="https://github.com/ml-explore/mlx-examples/assets/11355002/6ad41325-c3ed-40a6-b50d-c1a4e57a6ee9">

