### PR TITLE
Upload uses multi_commits when uploading to HF

### DIFF
--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -469,6 +469,8 @@ def upload_to_hub(path: str, upload_repo: str, hf_path: str):
         folder_path=path,
         repo_id=upload_repo,
         repo_type="model",
+        multi_commits=True,
+        multi_commits_verbose=True,
     )
     print(f"Upload successful, go to https://huggingface.co/{upload_repo} for details.")
 

--- a/lora/utils.py
+++ b/lora/utils.py
@@ -64,6 +64,8 @@ python generate.py --model {repo_id} --prompt "My name is"
         folder_path=path,
         repo_id=repo_id,
         repo_type="model",
+        multi_commits=True,
+        multi_commits_verbose=True,
     )
 
 


### PR DESCRIPTION
This PR uses an experimental feature in the HuggingFace API that creates multiple commits per upload. It is very convenient for big models with multiple files. It also allows for resuming the upload if something fails by simply re-running the command. I've tested it with `convert`, it looks [like this](https://huggingface.co/mlx-community/zephyr-orpo-141b-A35b-v0.1-8bit/discussions/2).