### PR TITLE
Add optional EOS token for llava example

### DIFF
--- a/llava/generate.py
+++ b/llava/generate.py
@@ -11,6 +11,7 @@ from transformers import AutoProcessor
 
 from llava import LlavaModel
 
+
 def parse_arguments():
     parser = argparse.ArgumentParser(
         description="Generate text from an image using a model."
@@ -40,10 +41,7 @@ def parse_arguments():
         help="Maximum number of tokens to generate.",
     )
     parser.add_argument(
-        "--temp",
-        type=float,
-        default=0.3,
-        help="Temperature for sampling."
+        "--temp", type=float, default=0.3, help="Temperature for sampling."
     )
     parser.add_argument(
         "--eos-token",
@@ -52,6 +50,7 @@ def parse_arguments():
         help="End of sequence token for tokenizer",
     )
     return parser.parse_args()
+
 
 def load_image(image_source):
     """
@@ -85,6 +84,7 @@ def prepare_inputs(processor, image, prompt):
     input_ids = mx.array(inputs["input_ids"])
     return input_ids, pixel_values
 
+
 def load_model(model_path, tokenizer_config={}):
     processor = AutoProcessor.from_pretrained(model_path, **tokenizer_config)
     model = LlavaModel.from_pretrained(model_path)
@@ -96,6 +96,7 @@ def sample(logits, temperature=0.0):
         return mx.argmax(logits, axis=-1)
     else:
         return mx.random.categorical(logits * (1 / temperature))
+
 
 def generate_text(input_ids, pixel_values, model, processor, max_tokens, temperature):
     logits, cache = model(input_ids, pixel_values)
@@ -114,12 +115,13 @@ def generate_text(input_ids, pixel_values, model, processor, max_tokens, tempera
 
     return processor.tokenizer.decode(tokens)
 
+
 def main():
     args = parse_arguments()
 
     tokenizer_config = {}
     if args.eos_token is not None:
-        tokenizer_config['eos_token'] = args.eos_token
+        tokenizer_config["eos_token"] = args.eos_token
 
     processor, model = load_model(args.model, tokenizer_config)
 
@@ -132,6 +134,7 @@ def main():
         input_ids, pixel_values, model, processor, args.max_tokens, args.temp
     )
     print(generated_text)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Some other flavors of llava models have different EOS tokens, and noticed this example didn't have a way to override it. So I added an optional parameter. 

**example without custom EOS**
```python
➜  llava git:(main) ✗ python generate.py \
  --model xtuner/llava-phi-3-mini-hf \
  --image "http://images.cocodataset.org/val2017/000000039769.jpg" \
  --prompt "USER: <image>\nWhat are these?\nASSISTANT:" \
  --max-tokens 128 \
  --temp 0

USER: <image>
What are these?
ASSISTANT:
These are two cats sleeping on a pink couch.<|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|><|end|>
Time: 0h:00m:39s
```

**example with custom EOS**
```python
➜  llava git:(main) ✗ python generate.py \
  --model xtuner/llava-phi-3-mini-hf \
  --image "http://images.cocodataset.org/val2017/000000039769.jpg" \
  --prompt "USER: <image>\nWhat are these?\nASSISTANT:" \
  --max-tokens 128 \
  --temp 0 --eos-token "<|end|>"

USER: <image>
What are these?
ASSISTANT:
These are two cats sleeping on a pink couch.
Time: 0h:00m:11s
```

