### PR TITLE
Add `model_config` parameter to `load()` and `load_model()`

### DIFF
--- a/llms/mlx_lm/tuner/trainer.py
+++ b/llms/mlx_lm/tuner/trainer.py
@@ -64,7 +64,7 @@ class TrainingArgs:
 
 
 def default_loss(model, inputs, targets, lengths):
-    logits, _ = model(inputs)
+    logits = model(inputs)
     logits = logits.astype(mx.float32)
 
     length_mask = mx.arange(inputs.shape[1])[None, :] < lengths[:, None]

--- a/llms/mlx_lm/tuner/trainer.py
+++ b/llms/mlx_lm/tuner/trainer.py
@@ -64,7 +64,7 @@ class TrainingArgs:
 
 
 def default_loss(model, inputs, targets, lengths):
-    logits = model(inputs)
+    logits, _ = model(inputs)
     logits = logits.astype(mx.float32)
 
     length_mask = mx.arange(inputs.shape[1])[None, :] < lengths[:, None]

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -299,17 +299,21 @@ def load_config(model_path: Path) -> dict:
     return config
 
 
-def load_model(model_path: Path, model_config: dict = {}, lazy: bool = False) -> nn.Module:
+def load_model(
+    model_path: Path,
+    lazy: bool = False,
+    model_config: dict = {},
+) -> nn.Module:
     """
     Load and initialize the model from a given path.
 
     Args:
         model_path (Path): The path to load the model from.
-        model_config(dict, optional): Configuration parameters for the model.
-            Defaults to an empty dictionary.
         lazy (bool): If False eval the model parameters to make sure they are
             loaded in memory before returning, otherwise they will be loaded
             when needed. Default: ``False``
+        model_config(dict, optional): Configuration parameters for the model.
+            Defaults to an empty dictionary.
 
     Returns:
         nn.Module: The loaded and initialized model.
@@ -395,7 +399,7 @@ def load(
     """
     model_path = get_model_path(path_or_hf_repo)
 
-    model = load_model(model_path, model_config, lazy)
+    model = load_model(model_path, lazy, model_config)
     if adapter_path is not None:
         model = apply_lora_layers(model, adapter_path)
         model.eval()

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -299,12 +299,14 @@ def load_config(model_path: Path) -> dict:
     return config
 
 
-def load_model(model_path: Path, lazy: bool = False) -> nn.Module:
+def load_model(model_path: Path, model_config: dict = {}, lazy: bool = False) -> nn.Module:
     """
     Load and initialize the model from a given path.
 
     Args:
         model_path (Path): The path to load the model from.
+        model_config(dict, optional): Configuration parameters for the model.
+            Defaults to an empty dictionary.
         lazy (bool): If False eval the model parameters to make sure they are
             loaded in memory before returning, otherwise they will be loaded
             when needed. Default: ``False``
@@ -318,6 +320,7 @@ def load_model(model_path: Path, lazy: bool = False) -> nn.Module:
     """
 
     config = load_config(model_path)
+    config.update(model_config)
 
     weight_files = glob.glob(str(model_path / "model*.safetensors"))
 
@@ -365,6 +368,7 @@ def load_model(model_path: Path, lazy: bool = False) -> nn.Module:
 def load(
     path_or_hf_repo: str,
     tokenizer_config={},
+    model_config={},
     adapter_path: Optional[str] = None,
     lazy: bool = False,
 ) -> Tuple[nn.Module, TokenizerWrapper]:
@@ -374,6 +378,8 @@ def load(
     Args:
         path_or_hf_repo (Path): The path or the huggingface repository to load the model from.
         tokenizer_config (dict, optional): Configuration parameters specifically for the tokenizer.
+            Defaults to an empty dictionary.
+        model_config(dict, optional): Configuration parameters specifically for the model.
             Defaults to an empty dictionary.
         adapter_path (str, optional): Path to the LoRA adapters. If provided, applies LoRA layers
             to the model. Default: ``None``.
@@ -389,7 +395,7 @@ def load(
     """
     model_path = get_model_path(path_or_hf_repo)
 
-    model = load_model(model_path, lazy)
+    model = load_model(model_path, model_config, lazy)
     if adapter_path is not None:
         model = apply_lora_layers(model, adapter_path)
         model.eval()


### PR DESCRIPTION
For easy editing of the loaded model configuration (e.g., increasing RoPE base frequency or PI). Example:

```python
from mlx_lm import load, generate
model, tokenizer = load("mlx-community/Phi-3-mini-4k-instruct-4bit-no-q-embed", model_config={"rope_theta":50000.0})
response = generate(model, tokenizer, prompt)
```

Output with default rope_theta of 10000.0:
![image](https://github.com/ml-explore/mlx-examples/assets/146810011/b89be852-ba71-42e6-b484-79311276d95e)

Output with modified rope_theta:
![image](https://github.com/ml-explore/mlx-examples/assets/146810011/f8e36220-5758-4d75-9a22-2fc3afcdb020)


