### PR TITLE
fix: Added dedicated error handling to load and get_model_path

### DIFF
--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Dict, Generator, Optional, Tuple, Union
 import mlx.core as mx
 import mlx.nn as nn
 from huggingface_hub import snapshot_download
+from huggingface_hub.utils._errors import RepositoryNotFoundError
 from mlx.utils import tree_flatten
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
@@ -90,7 +91,7 @@ def get_model_path(path_or_hf_repo: str, revision: Optional[str] = None) -> Path
                 )
             )
         except RepositoryNotFoundError:
-            raise RepoNotFoundError(f"No local or Hugging Face repository found for path: {path_or_hf_repo}.")
+            raise RepoNotFoundError(f"Model Not Found for {path_or_hf_repo}.\n Please make sure you specified the local path or Hugging Face repo id correctly.\n If you are trying to access a private or gated Hugging Face repo, make sure you are authenticated.")
     return model_path
 
 

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -406,10 +406,7 @@ def load(
         FileNotFoundError: If config file or safetensors are not found.
         ValueError: If model class or args class are not found.
     """
-    try:
-        model_path = get_model_path(path_or_hf_repo)
-    except RepoNotFoundError:
-        raise RepoNotFoundError(f"No local or Hugging Face repository found for path: {path_or_hf_repo}. Please check the provided path again.")
+    model_path = get_model_path(path_or_hf_repo)
 
     model = load_model(model_path, lazy, model_config)
     if adapter_path is not None:

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -33,11 +33,13 @@ MODEL_REMAPPING = {
 
 MAX_FILE_SIZE_GB = 5
 
+
 # Custom error class for no local or huggingface repo found for path
 class RepoNotFoundError(Exception):
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
+
 
 def _get_classes(config: dict):
     """
@@ -91,7 +93,13 @@ def get_model_path(path_or_hf_repo: str, revision: Optional[str] = None) -> Path
                 )
             )
         except RepositoryNotFoundError:
-            raise RepoNotFoundError(f"Model Not Found for {path_or_hf_repo}.\n Please make sure you specified the local path or Hugging Face repo id correctly.\n If you are trying to access a private or gated Hugging Face repo, make sure you are authenticated.")
+            raise RepoNotFoundError(
+                f"Model not found for path or HF repo: {path_or_hf_repo}.\n"
+                "Please make sure you specified the local path or Hugging Face"
+                " repo id correctly.\nIf you are trying to access a private or"
+                " gated Hugging Face repo, make sure you are authenticated:\n"
+                "https://huggingface.co/docs/huggingface_hub/en/guides/cli#huggingface-cli-login"
+            ) from None
     return model_path
 
 

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -34,8 +34,7 @@ MODEL_REMAPPING = {
 MAX_FILE_SIZE_GB = 5
 
 
-# Custom error class for no local or huggingface repo found for path
-class RepoNotFoundError(Exception):
+class ModelNotFoundError(Exception):
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
@@ -93,7 +92,7 @@ def get_model_path(path_or_hf_repo: str, revision: Optional[str] = None) -> Path
                 )
             )
         except RepositoryNotFoundError:
-            raise RepoNotFoundError(
+            raise ModelNotFoundError(
                 f"Model not found for path or HF repo: {path_or_hf_repo}.\n"
                 "Please make sure you specified the local path or Hugging Face"
                 " repo id correctly.\nIf you are trying to access a private or"


### PR DESCRIPTION
Added proper error handling to `load` and `get_model_path` by adding a dedicated exception class, because when the local path is not right, it still throws the huggingface `RepositoryNotFoundError`, which is not fully informative to the end user, they might have just entered their local path wrong by one character.