### PR TITLE
Block sparse MM MoEs

### DIFF
--- a/llms/mlx_lm/fuse.py
+++ b/llms/mlx_lm/fuse.py
@@ -7,7 +7,7 @@ from mlx.utils import tree_flatten, tree_unflatten
 
 from .gguf import convert_to_gguf
 from .tuner.dora import DoRALinear
-from .tuner.lora import LoRALinear
+from .tuner.lora import LoRALinear, LoRASwitchLinear
 from .tuner.utils import apply_lora_layers, dequantize
 from .utils import (
     fetch_from_hub,
@@ -82,7 +82,7 @@ def main() -> None:
     fused_linears = [
         (n, m.to_linear())
         for n, m in model.named_modules()
-        if isinstance(m, (LoRALinear, DoRALinear))
+        if isinstance(m, (LoRASwitchLinear, LoRALinear, DoRALinear))
     ]
 
     model.update_modules(tree_unflatten(fused_linears))

--- a/llms/mlx_lm/models/mixtral.py
+++ b/llms/mlx_lm/models/mixtral.py
@@ -205,7 +205,9 @@ class Model(nn.Module):
                     weights.pop(f"{prefix}.block_sparse_moe.experts.{e}.{n}.weight")
                     for e in range(self.args.num_local_experts)
                 ]
-                weights[f"{prefix}.block_sparse_moe.switch_mlp.{m}"] = mx.stack(to_join)
+                weights[f"{prefix}.block_sparse_moe.switch_mlp.{m}.weight"] = mx.stack(
+                    to_join
+                )
         return weights
 
     @property

--- a/llms/mlx_lm/models/mixtral.py
+++ b/llms/mlx_lm/models/mixtral.py
@@ -201,13 +201,15 @@ class Model(nn.Module):
         for l in range(self.args.num_hidden_layers):
             prefix = f"model.layers.{l}"
             for n, m in [("w1", "gate_proj"), ("w2", "down_proj"), ("w3", "up_proj")]:
-                to_join = [
-                    weights.pop(f"{prefix}.block_sparse_moe.experts.{e}.{n}.weight")
-                    for e in range(self.args.num_local_experts)
-                ]
-                weights[f"{prefix}.block_sparse_moe.switch_mlp.{m}.weight"] = mx.stack(
-                    to_join
-                )
+                for k in ["weight", "scales", "biases"]:
+                    to_join = [
+                        weights.pop(f"{prefix}.block_sparse_moe.experts.{e}.{n}.{k}")
+                        for e in range(self.args.num_local_experts)
+                    ]
+                    if to_join:
+                        weights[f"{prefix}.block_sparse_moe.switch_mlp.{m}.{k}"] = (
+                            mx.stack(to_join)
+                        )
         return weights
 
     @property

--- a/llms/mlx_lm/models/phixtral.py
+++ b/llms/mlx_lm/models/phixtral.py
@@ -75,15 +75,106 @@ class RoPEAttention(nn.Module):
         return self.out_proj(output)
 
 
-class MLP(nn.Module):
-    def __init__(self, dim, hidden_dim):
+class QuantizedSwitchMLP(nn.Module):
+    def __init__(self, dim, hidden_dim, num_experts, group_size=64, bits=4):
         super().__init__()
-        self.fc1 = nn.Linear(dim, hidden_dim)
-        self.fc2 = nn.Linear(hidden_dim, dim)
+        scale_in = math.sqrt(1 / dim)
+        scale_hidden = math.sqrt(1 / hidden_dim)
+        self.fc1_w, self.fc1_s, self.fc1_b = mx.quantize(
+            mx.random.uniform(
+                low=-scale_in,
+                high=scale_in,
+                shape=(num_experts, hidden_dim, dim),
+            ),
+            group_size=group_size,
+            bits=bits,
+        )
+        self.fc2_w, self.fc2_s, self.fc2_b = mx.quantize(
+            mx.random.uniform(
+                low=-scale_hidden,
+                high=scale_hidden,
+                shape=(num_experts, dim, hidden_dim),
+            ),
+            group_size=group_size,
+            bits=bits,
+        )
+        self.fc1_bias = mx.zeros((num_experts, hidden_dim))
+        self.fc2_bias = mx.zeros((num_experts, dim))
         self.act = nn.GELU(approx="precise")
+        self.num_experts = num_experts
+        self.group_size = group_size
+        self.bits = bits
 
-    def __call__(self, x) -> mx.array:
-        return self.fc2(self.act(self.fc1(x)))
+    def __call__(self, x, indices) -> mx.array:
+        x = mx.expand_dims(x, (-2, -3))
+        x = mx.block_sparse_qmm(
+            x,
+            self["fc1_w"],
+            self["fc1_s"],
+            self["fc1_b"],
+            rhs_indices=indices,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+        )
+        x = self.act(x)
+        x = mx.block_sparse_qmm(
+            x,
+            self["fc2_w"],
+            self["fc2_s"],
+            self["fc2_b"],
+            rhs_indices=indices,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+        )
+
+        return x.squeeze(-2)
+
+
+class SwitchMLP(nn.Module):
+    def __init__(self, dim, hidden_dim, num_experts):
+        super().__init__()
+        scale_in = math.sqrt(1 / dim)
+        scale_hidden = math.sqrt(1 / hidden_dim)
+        self.fc1 = mx.random.uniform(
+            low=-scale_in,
+            high=scale_in,
+            shape=(num_experts, hidden_dim, dim),
+        )
+        self.fc2 = mx.random.uniform(
+            low=-scale_hidden,
+            high=scale_hidden,
+            shape=(num_experts, dim, hidden_dim),
+        )
+        self.fc1_bias = mx.zeros((num_experts, hidden_dim))
+        self.fc2_bias = mx.zeros((num_experts, dim))
+        self.act = nn.GELU(approx="precise")
+        self.num_experts = num_experts
+
+    def __call__(self, x, indices) -> mx.array:
+        x = mx.expand_dims(x, (-2, -3))
+        x = mx.block_sparse_mm(x, self.fc1.swapaxes(-1, -2), rhs_indices=indices)
+        x = x + mx.expand_dims(self.fc1_bias[indices], -2)
+        x = self.act(x)
+        x = mx.block_sparse_mm(x, self.fc2.swapaxes(-1, -2), rhs_indices=indices)
+        x = x.squeeze(-2) + self.fc2_bias[indices]
+
+        return x
+
+    def to_quantized(self, group_size=64, bits=4):
+        num_experts, hidden_dim, dim = self.fc1.shape
+        qm = QuantizedSwitchMLP(dim, hidden_dim, num_experts)
+        qm.fc1_w, qm.fc1_s, qm.fc1_b = mx.quantize(
+            self.fc1, group_size=group_size, bits=bits
+        )
+        qm.fc2_w, qm.fc2_s, qm.fc2_b = mx.quantize(
+            self.fc2, group_size=group_size, bits=bits
+        )
+        return qm
+
+    def is_quantized(self, weights, prefix):
+        return f"{prefix}.fc1_s" in weights
 
 
 class MOE(nn.Module):
@@ -93,40 +184,21 @@ class MOE(nn.Module):
         self.hidden_dim = hidden_dim
         self.num_experts = args.num_local_experts
         self.num_experts_per_tok = args.num_experts_per_tok
-        self.mlp = [MLP(self.dim, self.hidden_dim) for _ in range(self.num_experts)]
+        self.switch_mlp = SwitchMLP(self.dim, self.hidden_dim, self.num_experts)
         self.gate = nn.Linear(args.model_dim, self.num_experts, bias=False)
 
     def __call__(self, x: mx.array) -> mx.array:
-        ne = self.num_experts_per_tok
-        orig_shape = x.shape
-        x = x.reshape(-1, x.shape[-1])
-
         gates = self.gate(x)
-        inds = mx.stop_gradient(mx.argpartition(-gates, kth=ne - 1, axis=-1))[:, :ne]
-        scores = mx.softmax(
-            mx.take_along_axis(gates, inds, axis=-1).astype(mx.float32),
-            axis=-1,
-        ).astype(gates.dtype)
 
-        if self.training:
-            ys = []
-            y = mx.zeros((x.shape[0], ne, x.shape[-1]), x.dtype)
-            for e, expert in enumerate(self.mlp):
-                idx1, idx2 = map(mx.array, np.where(inds == e))
-                if idx1.size == 0:
-                    continue
-                y[idx1, idx2] = expert(x[idx1])
+        k = self.num_experts_per_tok
+        inds = mx.stop_gradient(mx.argpartition(-gates, kth=k - 1, axis=-1))[..., :k]
+        scores = mx.take_along_axis(gates, inds, axis=-1)
+        scores = mx.softmax(scores, axis=-1, precise=True)
 
-            y = (y * scores[..., None]).sum(axis=1)
-        else:
-            y = []
-            for xt, st, it in zip(x, scores, inds.tolist()):
-                yt = mx.stack([self.mlp[e](xt) for e in it], axis=-1)
-                yt = (yt * st).sum(axis=-1)
-                y.append(yt[None, :])
-            y = mx.concatenate(y)
+        y = self.switch_mlp(x, inds)
+        y = (y * scores[..., None]).sum(axis=-2)
 
-        return y.reshape(orig_shape)
+        return y
 
 
 class ParallelBlock(nn.Module):
@@ -201,6 +273,24 @@ class Model(nn.Module):
 
         y = self.transformer(x, mask, cache)
         return self.lm_head(y)
+
+    def sanitize(self, weights):
+        if "transformer.h.0.moe.mlp.0.fc1.weight" not in weights:
+            return weights
+        for l in range(self.args.num_layers):
+            prefix = f"transformer.h.{l}"
+            for n in ["fc1", "fc2"]:
+                to_join = [
+                    weights.pop(f"{prefix}.moe.mlp.{e}.{n}.weight")
+                    for e in range(self.args.num_local_experts)
+                ]
+                weights[f"{prefix}.moe.switch_mlp.{n}"] = mx.stack(to_join)
+                to_join = [
+                    weights.pop(f"{prefix}.moe.mlp.{e}.{n}.bias")
+                    for e in range(self.args.num_local_experts)
+                ]
+                weights[f"{prefix}.moe.switch_mlp.{n}_bias"] = mx.stack(to_join)
+        return weights
 
     @property
     def layers(self):

--- a/llms/mlx_lm/models/phixtral.py
+++ b/llms/mlx_lm/models/phixtral.py
@@ -185,12 +185,12 @@ class Model(nn.Module):
                     weights.pop(f"{prefix}.moe.mlp.{e}.{n}.weight")
                     for e in range(self.args.num_local_experts)
                 ]
-                weights[f"{prefix}.moe.switch_mlp.{n}"] = mx.stack(to_join)
+                weights[f"{prefix}.moe.switch_mlp.{n}.weight"] = mx.stack(to_join)
                 to_join = [
                     weights.pop(f"{prefix}.moe.mlp.{e}.{n}.bias")
                     for e in range(self.args.num_local_experts)
                 ]
-                weights[f"{prefix}.moe.switch_mlp.{n}_bias"] = mx.stack(to_join)
+                weights[f"{prefix}.moe.switch_mlp.{n}.bias"] = mx.stack(to_join)
         return weights
 
     @property

--- a/llms/mlx_lm/models/phixtral.py
+++ b/llms/mlx_lm/models/phixtral.py
@@ -181,16 +181,13 @@ class Model(nn.Module):
         for l in range(self.args.num_layers):
             prefix = f"transformer.h.{l}"
             for n in ["fc1", "fc2"]:
-                to_join = [
-                    weights.pop(f"{prefix}.moe.mlp.{e}.{n}.weight")
-                    for e in range(self.args.num_local_experts)
-                ]
-                weights[f"{prefix}.moe.switch_mlp.{n}.weight"] = mx.stack(to_join)
-                to_join = [
-                    weights.pop(f"{prefix}.moe.mlp.{e}.{n}.bias")
-                    for e in range(self.args.num_local_experts)
-                ]
-                weights[f"{prefix}.moe.switch_mlp.{n}.bias"] = mx.stack(to_join)
+                for k in ["weight", "scales", "biases", "bias"]:
+                    to_join = [
+                        weights.pop(f"{prefix}.moe.mlp.{e}.{n}.{k}")
+                        for e in range(self.args.num_local_experts)
+                    ]
+                    if to_join:
+                        weights[f"{prefix}.moe.switch_mlp.{n}.{k}"] = mx.stack(to_join)
         return weights
 
     @property

--- a/llms/mlx_lm/models/qwen2_moe.py
+++ b/llms/mlx_lm/models/qwen2_moe.py
@@ -224,11 +224,13 @@ class Model(nn.Module):
         for l in range(self.args.num_hidden_layers):
             prefix = f"model.layers.{l}"
             for n in ["up_proj", "down_proj", "gate_proj"]:
-                to_join = [
-                    weights.pop(f"{prefix}.mlp.experts.{e}.{n}.weight")
-                    for e in range(self.args.num_experts)
-                ]
-                weights[f"{prefix}.mlp.switch_mlp.{n}.weight"] = mx.stack(to_join)
+                for k in ["weight", "scales", "biases"]:
+                    to_join = [
+                        weights.pop(f"{prefix}.mlp.experts.{e}.{n}.{k}")
+                        for e in range(self.args.num_experts)
+                    ]
+                    if to_join:
+                        weights[f"{prefix}.mlp.switch_mlp.{n}.{k}"] = mx.stack(to_join)
         return weights
 
     @property

--- a/llms/mlx_lm/models/qwen2_moe.py
+++ b/llms/mlx_lm/models/qwen2_moe.py
@@ -228,7 +228,7 @@ class Model(nn.Module):
                     weights.pop(f"{prefix}.mlp.experts.{e}.{n}.weight")
                     for e in range(self.args.num_experts)
                 ]
-                weights[f"{prefix}.mlp.switch_mlp.{n}"] = mx.stack(to_join)
+                weights[f"{prefix}.mlp.switch_mlp.{n}.weight"] = mx.stack(to_join)
         return weights
 
     @property

--- a/llms/mlx_lm/models/switch_layers.py
+++ b/llms/mlx_lm/models/switch_layers.py
@@ -4,111 +4,81 @@ import mlx.core as mx
 import mlx.nn as nn
 
 
-class QuantizedSwitchGLU(nn.Module):
+class QuqntizedSwitchLinear(nn.Module):
     def __init__(
         self,
         input_dims: int,
-        hidden_dims: int,
+        output_dims: int,
         num_experts: int,
-        activation=nn.silu,
-        bias: bool = False,
+        bias: bool = True,
         group_size: int = 64,
         bits: int = 4,
     ):
         super().__init__()
-        scale_in = math.sqrt(1 / input_dims)
-        scale_hidden = math.sqrt(1 / hidden_dims)
 
-        self.gate_proj_w, self.gate_proj_s, self.gate_proj_b = mx.quantize(
+        scale = math.sqrt(1 / input_dims)
+        self.weight, self.scales, self.biases = mx.quantize(
             mx.random.uniform(
-                low=-scale_in,
-                high=scale_in,
-                shape=(num_experts, hidden_dims, input_dims),
-            ),
-            group_size=group_size,
-            bits=bits,
-        )
-        self.up_proj_w, self.up_proj_s, self.up_proj_b = mx.quantize(
-            mx.random.uniform(
-                low=-scale_in,
-                high=scale_in,
-                shape=(num_experts, hidden_dims, input_dims),
-            ),
-            group_size=group_size,
-            bits=bits,
-        )
-        self.down_proj_w, self.down_proj_s, self.down_proj_b = mx.quantize(
-            mx.random.uniform(
-                low=-scale_hidden,
-                high=scale_hidden,
-                shape=(num_experts, input_dims, hidden_dims),
+                low=-scale,
+                high=scale,
+                shape=(num_experts, output_dims, input_dims),
             ),
             group_size=group_size,
             bits=bits,
         )
 
         if bias:
-            self.gate_proj_bias = mx.zeros((num_experts, hidden_dims))
-            self.up_proj_bias = mx.zeros((num_experts, hidden_dims))
-            self.down_proj_bias = mx.zeros((num_experts, input_dims))
+            self.bias = mx.zeros((num_experts, output_dims))
 
-        self.activation = activation
-
-        self.num_experts = num_experts
         self.group_size = group_size
         self.bits = bits
 
-    def __call__(self, x, indices) -> mx.array:
-        have_bias = "up_proj_bias" in self
-
-        # Prepare the input for block sparse matmuls
-        x = mx.expand_dims(x, (-2, -3))
-
-        # Up project the input
-        x_up = mx.block_sparse_qmm(
-            x,
-            self["up_proj_w"],
-            self["up_proj_s"],
-            self["up_proj_b"],
-            rhs_indices=indices,
-            transpose=True,
-            group_size=self.group_size,
-            bits=self.bits,
-        )
-        if have_bias:
-            x_up = x_up + mx.expand_dims(self.up_proj_bias[indices], -2)
-
-        # Compute the gate
-        x_gate = mx.block_sparse_qmm(
-            x,
-            self["gate_proj_w"],
-            self["gate_proj_s"],
-            self["gate_proj_b"],
-            rhs_indices=indices,
-            transpose=True,
-            group_size=self.group_size,
-            bits=self.bits,
-        )
-        if have_bias:
-            x_gate = x_gate + mx.expand_dims(self.gate_proj_bias[indices], -2)
-
-        # Compute the final projection
-        x = self.activation(x_gate) * x_up
+    def __call__(self, x, indices):
         x = mx.block_sparse_qmm(
             x,
-            self["down_proj_w"],
-            self["down_proj_s"],
-            self["down_proj_b"],
+            self["weight"],
+            self["scales"],
+            self["biases"],
             rhs_indices=indices,
             transpose=True,
             group_size=self.group_size,
             bits=self.bits,
         )
-        x = x.squeeze(-2)
-        if have_bias:
-            x = x + self.down_proj_bias[indices]
-
+        if "bias" in self:
+            x = x + mx.expand_dims(self["bias"][indices], -2)
         return x
+
+
+class SwitchLinear(nn.Module):
+    def __init__(
+        self, input_dims: int, output_dims: int, num_experts: int, bias: bool = True
+    ):
+        super().__init__()
+        scale = math.sqrt(1 / input_dims)
+        self.weight = mx.random.uniform(
+            low=-scale,
+            high=scale,
+            shape=(num_experts, output_dims, input_dims),
+        )
+
+        if bias:
+            self.bias = mx.zeros((num_experts, output_dims))
+
+    def __call__(self, x, indices):
+        x = mx.block_sparse_mm(x, self["weight"].swapaxes(-1, -2), rhs_indices=indices)
+        if "bias" in self:
+            x = x + mx.expand_dims(self["bias"][indices], -2)
+        return x
+
+    def to_quantized(self, group_size: int = 64, bits: int = 4):
+        num_experts, output_dims, input_dims = self.weight.shape
+        ql = QuqntizedSwitchLinear(
+            input_dims, output_dims, num_experts, False, group_size, bits
+        )
+        ql.weight, ql.scales, ql.biases = mx.quantize(self.weight, group_size, bits)
+        if "bias" in self:
+            ql.bias = self.bias
+        return ql
 
 
 class SwitchGLU(nn.Module):
@@ -121,158 +91,20 @@ class SwitchGLU(nn.Module):
         bias: bool = False,
     ):
         super().__init__()
-        scale_in = math.sqrt(1 / input_dims)
-        scale_hidden = math.sqrt(1 / hidden_dims)
 
-        self.gate_proj = mx.random.uniform(
-            low=-scale_in,
-            high=scale_in,
-            shape=(num_experts, hidden_dims, input_dims),
-        )
-        self.up_proj = mx.random.uniform(
-            low=-scale_in,
-            high=scale_in,
-            shape=(num_experts, hidden_dims, input_dims),
-        )
-        self.down_proj = mx.random.uniform(
-            low=-scale_hidden,
-            high=scale_hidden,
-            shape=(num_experts, input_dims, hidden_dims),
-        )
-
-        if bias:
-            self.gate_proj_bias = mx.zeros((num_experts, hidden_dims))
-            self.up_proj_bias = mx.zeros((num_experts, hidden_dims))
-            self.down_proj_bias = mx.zeros((num_experts, input_dims))
-
+        self.gate_proj = SwitchLinear(input_dims, hidden_dims, num_experts, bias=bias)
+        self.up_proj = SwitchLinear(input_dims, hidden_dims, num_experts, bias=bias)
+        self.down_proj = SwitchLinear(hidden_dims, input_dims, num_experts, bias=bias)
         self.activation = activation
 
-        self.num_experts = num_experts
-
     def __call__(self, x, indices) -> mx.array:
-        have_bias = "up_proj_bias" in self
-
-        # Prepare the input for block sparse matmuls
         x = mx.expand_dims(x, (-2, -3))
 
-        # Up project the input
-        x_up = mx.block_sparse_mm(x, self.up_proj.swapaxes(-1, -2), rhs_indices=indices)
-        if have_bias:
-            x_up = x_up + mx.expand_dims(self.up_proj_bias[indices], -2)
+        x_up = self.up_proj(x, indices)
+        x_gate = self.gate_proj(x, indices)
+        x = self.down_proj(self.activation(x_gate) * x_up, indices)
 
-        # Compute the gate
-        x_gate = mx.block_sparse_mm(
-            x, self.gate_proj.swapaxes(-1, -2), rhs_indices=indices
-        )
-        if have_bias:
-            x_gate = x_gate + mx.expand_dims(self.gate_proj_bias[indices], -2)
-
-        # Compute the final projection
-        x = self.activation(x_gate) * x_up
-        x = mx.block_sparse_mm(x, self.down_proj.swapaxes(-1, -2), rhs_indices=indices)
-        x = x.squeeze(-2)
-        if have_bias:
-            x = x + self.down_proj_bias[indices]
-
-        return x
-
-    def to_quantized(self, group_size: int = 64, bits: int = 4):
-        num_experts, hidden_dim, dim = self.gate_proj.shape
-
-        qm = QuantizedSwitchGLU(dim, hidden_dim, num_experts)
-        qm.gate_proj_w, qm.gate_proj_s, qm.gate_proj_b = mx.quantize(
-            self.gate_proj, group_size=group_size, bits=bits
-        )
-        qm.up_proj_w, qm.up_proj_s, qm.up_proj_b = mx.quantize(
-            self.up_proj, group_size=group_size, bits=bits
-        )
-        qm.down_proj_w, qm.down_proj_s, qm.down_proj_b = mx.quantize(
-            self.down_proj, group_size=group_size, bits=bits
-        )
-
-        return qm
-
-    def is_quantized(self, weights, prefix):
-        return f"{prefix}.gate_proj_s" in weights
-
-
-class QuantizedSwitchMLP(nn.Module):
-    def __init__(
-        input_dims: int,
-        hidden_dims: int,
-        num_experts: int,
-        activation=nn.gelu_approx,
-        bias: bool = False,
-        group_size: int = 64,
-        bits: int = 4,
-    ):
-        super().__init__()
-        scale_in = math.sqrt(1 / input_dims)
-        scale_hidden = math.sqrt(1 / hidden_dims)
-
-        self.fc1_w, self.fc1_s, self.fc1_b = mx.quantize(
-            mx.random.uniform(
-                low=-scale_in,
-                high=scale_in,
-                shape=(num_experts, hidden_dim, dim),
-            ),
-            group_size=group_size,
-            bits=bits,
-        )
-        self.fc2_w, self.fc2_s, self.fc2_b = mx.quantize(
-            mx.random.uniform(
-                low=-scale_hidden,
-                high=scale_hidden,
-                shape=(num_experts, dim, hidden_dim),
-            ),
-            group_size=group_size,
-            bits=bits,
-        )
-        if bias:
-            self.fc1_bias = mx.zeros((num_experts, hidden_dims))
-            self.fc2_bias = mx.zeros((num_experts, input_dims))
-
-        self.act = activation
-
-        self.num_experts = num_experts
-        self.group_size = group_size
-        self.bits = bits
-
-    def __call__(self, x, indices) -> mx.array:
-        have_bias = "fc1_bias" in self
-
-        # Prepare the input for block sparse matmuls
-        x = mx.expand_dims(x, (-2, -3))
-
-        # Compute the MLP
-        x = mx.block_sparse_qmm(
-            x,
-            self["fc1_w"],
-            self["fc1_s"],
-            self["fc1_b"],
-            rhs_indices=indices,
-            transpose=True,
-            group_size=self.group_size,
-            bits=self.bits,
-        )
-        if have_bias:
-            x = x + mx.expand_dims(self.fc1_bias[indices], -2)
-        x = self.activation(x)
-        x = mx.block_sparse_qmm(
-            x,
-            self["fc2_w"],
-            self["fc2_s"],
-            self["fc2_b"],
-            rhs_indices=indices,
-            transpose=True,
-            group_size=self.group_size,
-            bits=self.bits,
-        )
-        x = x.squeeze(-2)
-        if have_bias:
-            x = x + self.fc2_bias[indices]
-
-        return x
+        return x.squeeze(-2)
 
 
 class SwitchMLP(nn.Module):
@@ -285,57 +117,16 @@ class SwitchMLP(nn.Module):
         bias: bool = False,
     ):
         super().__init__()
-        scale_in = math.sqrt(1 / input_dims)
-        scale_hidden = math.sqrt(1 / hidden_dims)
 
-        self.fc1 = mx.random.uniform(
-            low=-scale_in,
-            high=scale_in,
-            shape=(num_experts, hidden_dims, input_dims),
-        )
-        self.fc2 = mx.random.uniform(
-            low=-scale_hidden,
-            high=scale_hidden,
-            shape=(num_experts, input_dims, hidden_dims),
-        )
-
-        if bias:
-            self.fc1_bias = mx.zeros((num_experts, hidden_dims))
-            self.fc2_bias = mx.zeros((num_experts, input_dims))
-
+        self.fc1 = SwitchLinear(input_dims, hidden_dims, num_experts, bias=bias)
+        self.fc2 = SwitchLinear(hidden_dims, input_dims, num_experts, bias=bias)
         self.activation = activation
-        self.num_experts = num_experts
 
     def __call__(self, x, indices) -> mx.array:
-        have_bias = "fc1_bias" in self
-
-        # Prepare the input for block sparse matmuls
         x = mx.expand_dims(x, (-2, -3))
 
-        # Compute the MLP
-        x = mx.block_sparse_mm(x, self.fc1.swapaxes(-1, -2), rhs_indices=indices)
-        if have_bias:
-            x = x + mx.expand_dims(self.fc1_bias[indices], -2)
+        x = self.fc1(x, indices)
         x = self.activation(x)
-        x = mx.block_sparse_mm(x, self.fc2.swapaxes(-1, -2), rhs_indices=indices)
-        x = x.squeeze(-2)
-        if have_bias:
-            x = x + self.fc2_bias[indices]
+        x = self.fc2(x, indices)
 
-        return x
-
-    def to_quantized(self, group_size: int = 64, bits: int = 4):
-        num_experts, hidden_dim, dim = self.fc1.shape
-
-        qm = QuantizedSwitchMLP(dim, hidden_dim, num_experts)
-        qm.fc1_w, qm.fc1_s, qm.fc1_b = mx.quantize(
-            self.fc1, group_size=group_size, bits=bits
-        )
-        qm.fc2_w, qm.fc2_s, qm.fc2_b = mx.quantize(
-            self.fc2, group_size=group_size, bits=bits
-        )
-
-        return qm
-
-    def is_quantized(self, weights, prefix):
-        return f"{prefix}.fc1_s" in weights
+        return x.squeeze(-2)

--- a/llms/mlx_lm/models/switch_layers.py
+++ b/llms/mlx_lm/models/switch_layers.py
@@ -1,0 +1,341 @@
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class QuantizedSwitchGLU(nn.Module):
+    def __init__(
+        self,
+        input_dims: int,
+        hidden_dims: int,
+        num_experts: int,
+        activation=nn.silu,
+        bias: bool = False,
+        group_size: int = 64,
+        bits: int = 4,
+    ):
+        super().__init__()
+        scale_in = math.sqrt(1 / input_dims)
+        scale_hidden = math.sqrt(1 / hidden_dims)
+
+        self.gate_proj_w, self.gate_proj_s, self.gate_proj_b = mx.quantize(
+            mx.random.uniform(
+                low=-scale_in,
+                high=scale_in,
+                shape=(num_experts, hidden_dims, input_dims),
+            ),
+            group_size=group_size,
+            bits=bits,
+        )
+        self.up_proj_w, self.up_proj_s, self.up_proj_b = mx.quantize(
+            mx.random.uniform(
+                low=-scale_in,
+                high=scale_in,
+                shape=(num_experts, hidden_dims, input_dims),
+            ),
+            group_size=group_size,
+            bits=bits,
+        )
+        self.down_proj_w, self.down_proj_s, self.down_proj_b = mx.quantize(
+            mx.random.uniform(
+                low=-scale_hidden,
+                high=scale_hidden,
+                shape=(num_experts, input_dims, hidden_dims),
+            ),
+            group_size=group_size,
+            bits=bits,
+        )
+
+        if bias:
+            self.gate_proj_bias = mx.zeros((num_experts, hidden_dims))
+            self.up_proj_bias = mx.zeros((num_experts, hidden_dims))
+            self.down_proj_bias = mx.zeros((num_experts, input_dims))
+
+        self.activation = activation
+
+        self.num_experts = num_experts
+        self.group_size = group_size
+        self.bits = bits
+
+    def __call__(self, x, indices) -> mx.array:
+        have_bias = "up_proj_bias" in self
+
+        # Prepare the input for block sparse matmuls
+        x = mx.expand_dims(x, (-2, -3))
+
+        # Up project the input
+        x_up = mx.block_sparse_qmm(
+            x,
+            self["up_proj_w"],
+            self["up_proj_s"],
+            self["up_proj_b"],
+            rhs_indices=indices,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+        )
+        if have_bias:
+            x_up = x_up + mx.expand_dims(self.up_proj_bias[indices], -2)
+
+        # Compute the gate
+        x_gate = mx.block_sparse_qmm(
+            x,
+            self["gate_proj_w"],
+            self["gate_proj_s"],
+            self["gate_proj_b"],
+            rhs_indices=indices,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+        )
+        if have_bias:
+            x_gate = x_gate + mx.expand_dims(self.gate_proj_bias[indices], -2)
+
+        # Compute the final projection
+        x = self.activation(x_gate) * x_up
+        x = mx.block_sparse_qmm(
+            x,
+            self["down_proj_w"],
+            self["down_proj_s"],
+            self["down_proj_b"],
+            rhs_indices=indices,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+        )
+        x = x.squeeze(-2)
+        if have_bias:
+            x = x + self.down_proj_bias[indices]
+
+        return x
+
+
+class SwitchGLU(nn.Module):
+    def __init__(
+        self,
+        input_dims: int,
+        hidden_dims: int,
+        num_experts: int,
+        activation=nn.silu,
+        bias: bool = False,
+    ):
+        super().__init__()
+        scale_in = math.sqrt(1 / input_dims)
+        scale_hidden = math.sqrt(1 / hidden_dims)
+
+        self.gate_proj = mx.random.uniform(
+            low=-scale_in,
+            high=scale_in,
+            shape=(num_experts, hidden_dims, input_dims),
+        )
+        self.up_proj = mx.random.uniform(
+            low=-scale_in,
+            high=scale_in,
+            shape=(num_experts, hidden_dims, input_dims),
+        )
+        self.down_proj = mx.random.uniform(
+            low=-scale_hidden,
+            high=scale_hidden,
+            shape=(num_experts, input_dims, hidden_dims),
+        )
+
+        if bias:
+            self.gate_proj_bias = mx.zeros((num_experts, hidden_dims))
+            self.up_proj_bias = mx.zeros((num_experts, hidden_dims))
+            self.down_proj_bias = mx.zeros((num_experts, input_dims))
+
+        self.activation = activation
+
+        self.num_experts = num_experts
+
+    def __call__(self, x, indices) -> mx.array:
+        have_bias = "up_proj_bias" in self
+
+        # Prepare the input for block sparse matmuls
+        x = mx.expand_dims(x, (-2, -3))
+
+        # Up project the input
+        x_up = mx.block_sparse_mm(x, self.up_proj.swapaxes(-1, -2), rhs_indices=indices)
+        if have_bias:
+            x_up = x_up + mx.expand_dims(self.up_proj_bias[indices], -2)
+
+        # Compute the gate
+        x_gate = mx.block_sparse_mm(
+            x, self.gate_proj.swapaxes(-1, -2), rhs_indices=indices
+        )
+        if have_bias:
+            x_gate = x_gate + mx.expand_dims(self.gate_proj_bias[indices], -2)
+
+        # Compute the final projection
+        x = self.activation(x_gate) * x_up
+        x = mx.block_sparse_mm(x, self.down_proj.swapaxes(-1, -2), rhs_indices=indices)
+        x = x.squeeze(-2)
+        if have_bias:
+            x = x + self.down_proj_bias[indices]
+
+        return x
+
+    def to_quantized(self, group_size: int = 64, bits: int = 4):
+        num_experts, hidden_dim, dim = self.gate_proj.shape
+
+        qm = QuantizedSwitchGLU(dim, hidden_dim, num_experts)
+        qm.gate_proj_w, qm.gate_proj_s, qm.gate_proj_b = mx.quantize(
+            self.gate_proj, group_size=group_size, bits=bits
+        )
+        qm.up_proj_w, qm.up_proj_s, qm.up_proj_b = mx.quantize(
+            self.up_proj, group_size=group_size, bits=bits
+        )
+        qm.down_proj_w, qm.down_proj_s, qm.down_proj_b = mx.quantize(
+            self.down_proj, group_size=group_size, bits=bits
+        )
+
+        return qm
+
+    def is_quantized(self, weights, prefix):
+        return f"{prefix}.gate_proj_s" in weights
+
+
+class QuantizedSwitchMLP(nn.Module):
+    def __init__(
+        input_dims: int,
+        hidden_dims: int,
+        num_experts: int,
+        activation=nn.gelu_approx,
+        bias: bool = False,
+        group_size: int = 64,
+        bits: int = 4,
+    ):
+        super().__init__()
+        scale_in = math.sqrt(1 / input_dims)
+        scale_hidden = math.sqrt(1 / hidden_dims)
+
+        self.fc1_w, self.fc1_s, self.fc1_b = mx.quantize(
+            mx.random.uniform(
+                low=-scale_in,
+                high=scale_in,
+                shape=(num_experts, hidden_dim, dim),
+            ),
+            group_size=group_size,
+            bits=bits,
+        )
+        self.fc2_w, self.fc2_s, self.fc2_b = mx.quantize(
+            mx.random.uniform(
+                low=-scale_hidden,
+                high=scale_hidden,
+                shape=(num_experts, dim, hidden_dim),
+            ),
+            group_size=group_size,
+            bits=bits,
+        )
+        if bias:
+            self.fc1_bias = mx.zeros((num_experts, hidden_dims))
+            self.fc2_bias = mx.zeros((num_experts, input_dims))
+
+        self.act = activation
+
+        self.num_experts = num_experts
+        self.group_size = group_size
+        self.bits = bits
+
+    def __call__(self, x, indices) -> mx.array:
+        have_bias = "fc1_bias" in self
+
+        # Prepare the input for block sparse matmuls
+        x = mx.expand_dims(x, (-2, -3))
+
+        # Compute the MLP
+        x = mx.block_sparse_qmm(
+            x,
+            self["fc1_w"],
+            self["fc1_s"],
+            self["fc1_b"],
+            rhs_indices=indices,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+        )
+        if have_bias:
+            x = x + mx.expand_dims(self.fc1_bias[indices], -2)
+        x = self.activation(x)
+        x = mx.block_sparse_qmm(
+            x,
+            self["fc2_w"],
+            self["fc2_s"],
+            self["fc2_b"],
+            rhs_indices=indices,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+        )
+        x = x.squeeze(-2)
+        if have_bias:
+            x = x + self.fc2_bias[indices]
+
+        return x
+
+
+class SwitchMLP(nn.Module):
+    def __init__(
+        self,
+        input_dims: int,
+        hidden_dims: int,
+        num_experts: int,
+        activation=nn.gelu_approx,
+        bias: bool = False,
+    ):
+        super().__init__()
+        scale_in = math.sqrt(1 / input_dims)
+        scale_hidden = math.sqrt(1 / hidden_dims)
+
+        self.fc1 = mx.random.uniform(
+            low=-scale_in,
+            high=scale_in,
+            shape=(num_experts, hidden_dims, input_dims),
+        )
+        self.fc2 = mx.random.uniform(
+            low=-scale_hidden,
+            high=scale_hidden,
+            shape=(num_experts, input_dims, hidden_dims),
+        )
+
+        if bias:
+            self.fc1_bias = mx.zeros((num_experts, hidden_dims))
+            self.fc2_bias = mx.zeros((num_experts, input_dims))
+
+        self.activation = activation
+        self.num_experts = num_experts
+
+    def __call__(self, x, indices) -> mx.array:
+        have_bias = "fc1_bias" in self
+
+        # Prepare the input for block sparse matmuls
+        x = mx.expand_dims(x, (-2, -3))
+
+        # Compute the MLP
+        x = mx.block_sparse_mm(x, self.fc1.swapaxes(-1, -2), rhs_indices=indices)
+        if have_bias:
+            x = x + mx.expand_dims(self.fc1_bias[indices], -2)
+        x = self.activation(x)
+        x = mx.block_sparse_mm(x, self.fc2.swapaxes(-1, -2), rhs_indices=indices)
+        x = x.squeeze(-2)
+        if have_bias:
+            x = x + self.fc2_bias[indices]
+
+        return x
+
+    def to_quantized(self, group_size: int = 64, bits: int = 4):
+        num_experts, hidden_dim, dim = self.fc1.shape
+
+        qm = QuantizedSwitchMLP(dim, hidden_dim, num_experts)
+        qm.fc1_w, qm.fc1_s, qm.fc1_b = mx.quantize(
+            self.fc1, group_size=group_size, bits=bits
+        )
+        qm.fc2_w, qm.fc2_s, qm.fc2_b = mx.quantize(
+            self.fc2, group_size=group_size, bits=bits
+        )
+
+        return qm
+
+    def is_quantized(self, weights, prefix):
+        return f"{prefix}.fc1_s" in weights

--- a/llms/mlx_lm/models/switch_layers.py
+++ b/llms/mlx_lm/models/switch_layers.py
@@ -33,6 +33,15 @@ class QuantizedSwitchLinear(nn.Module):
         self.group_size = group_size
         self.bits = bits
 
+        # Freeze this model's parameters
+        self.freeze()
+
+    def unfreeze(self, *args, **kwargs):
+        """Wrap unfreeze so that we unfreeze any layers we might contain but
+        our parameters will remain frozen."""
+        super().unfreeze(*args, **kwargs)
+        self.freeze(recurse=False)
+
     @property
     def input_dims(self):
         return self.scales.shape[2] * self.group_size

--- a/llms/mlx_lm/tuner/lora.py
+++ b/llms/mlx_lm/tuner/lora.py
@@ -5,6 +5,8 @@ import math
 import mlx.core as mx
 import mlx.nn as nn
 
+from ..models.switch_layers import QuantizedSwitchLinear, SwitchLinear
+
 
 class LoRALinear(nn.Module):
     @staticmethod
@@ -99,4 +101,99 @@ class LoRALinear(nn.Module):
     def __call__(self, x):
         y = self.linear(x)
         z = (self.dropout(x) @ self.lora_a) @ self.lora_b
+        return y + (self.scale * z).astype(x.dtype)
+
+
+class LoRASwitchLinear(nn.Module):
+    @staticmethod
+    def from_linear(
+        linear: nn.Module,
+        r: int = 8,
+        alpha: float = 16,
+        dropout: float = 0.0,
+        scale: float = 10.0,
+    ):
+        lora_lin = LoRASwitchLinear(
+            input_dims=linear.input_dims,
+            output_dims=linear.output_dims,
+            num_experts=linear.num_experts,
+            r=r,
+            alpha=alpha,
+            dropout=dropout,
+            scale=scale,
+        )
+        lora_lin.linear = linear
+        return lora_lin
+
+    def to_linear(self, de_quantize: bool = False):
+        linear = self.linear
+        bias = "bias" in linear
+        weight = linear.weight
+        is_quantized = isinstance(linear, QuantizedSwitchLinear)
+
+        # Use the same type as the linear weight if not quantized
+        dtype = weight.dtype
+
+        if is_quantized:
+            dtype = mx.float16
+            weight = mx.dequantize(
+                weight,
+                linear.scales,
+                linear.biases,
+                linear.group_size,
+                linear.bits,
+            )
+        num_experts, output_dims, input_dims = weight.shape
+        fused_linear = SwitchLinear(input_dims, output_dims, num_experts, bias=bias)
+
+        lora_b = (self.scale * self.lora_b).astype(dtype)
+        lora_a = self.lora_a.reshape(num_experts, -1, input_dims).astype(dtype)
+        fused_linear.weight = weight + lora_b @ lora_a
+        if bias:
+            fused_linear.bias = linear.bias
+
+        if is_quantized and not de_quantize:
+            fused_linear = fused_linear.to_quantized(linear.group_size, linear.bits)
+
+        return fused_linear
+
+    def __init__(
+        self,
+        input_dims: int,
+        output_dims: int,
+        num_experts: int,
+        r: int = 8,
+        alpha: float = 16,
+        dropout: float = 0.0,
+        scale: float = 10.0,
+        bias: bool = False,
+    ):
+        super().__init__()
+
+        # Regular linear layer weights
+        self.linear = SwitchLinear(input_dims, output_dims, num_experts, bias=bias)
+
+        self.dropout = nn.Dropout(p=dropout)
+
+        # Scale for low-rank update
+        self.scale = scale * (alpha / r)
+
+        # Low rank lora weights
+        scale = 1 / math.sqrt(input_dims)
+        self.lora_a = mx.random.uniform(
+            low=-scale,
+            high=scale,
+            shape=(r * num_experts, input_dims),
+        )
+        self.lora_b = mx.zeros(shape=(num_experts, output_dims, r))
+        self.num_experts = num_experts
+
+    def __call__(self, x, indices):
+        shape = x.shape[:-3] + (self.num_experts, -1)
+
+        y = self.linear(x, indices)
+        z = (self.dropout(x) @ self.lora_a.T).reshape(shape)
+        z = mx.take_along_axis(z, indices[..., None], axis=-2)
+        z = z[..., None, :] @ self.lora_b[indices].swapaxes(-2, -1)
+
         return y + (self.scale * z).astype(x.dtype)

--- a/llms/mlx_lm/tuner/utils.py
+++ b/llms/mlx_lm/tuner/utils.py
@@ -9,8 +9,9 @@ import mlx.nn as nn
 import mlx.optimizers as opt
 from mlx.utils import tree_unflatten
 
+from ..models.switch_layers import QuantizedSwitchLinear, SwitchLinear
 from .dora import DoRALinear
-from .lora import LoRALinear
+from .lora import LoRALinear, LoRASwitchLinear
 
 
 def build_schedule(schedule_config: Dict):
@@ -58,11 +59,17 @@ def linear_to_lora_layers(
             f"Requested {num_lora_layers} LoRA layers "
             f"but the model only has {num_layers} layers."
         )
-    cls = DoRALinear if use_dora else LoRALinear
 
-    def to_lora(lin):
-        return cls.from_linear(
-            lin,
+    def to_lora(layer):
+        if isinstance(layer, (nn.Linear, nn.QuantizedLinear)):
+            LoRALayer = DoRALinear if use_dora else LoRALinear
+        elif isinstance(layer, (SwitchLinear, QuantizedSwitchLinear)):
+            LoRALayer = LoRASwitchLinear
+        else:
+            raise ValueError(f"Can't convert layer of type {type(layer)} to LoRA")
+
+        return LoRALayer.from_linear(
+            layer,
             r=config["rank"],
             alpha=config["alpha"],
             scale=config["scale"],

--- a/llms/mlx_lm/tuner/utils.py
+++ b/llms/mlx_lm/tuner/utils.py
@@ -64,9 +64,13 @@ def linear_to_lora_layers(
         if isinstance(layer, (nn.Linear, nn.QuantizedLinear)):
             LoRALayer = DoRALinear if use_dora else LoRALinear
         elif isinstance(layer, (SwitchLinear, QuantizedSwitchLinear)):
+            if use_dora:
+                raise ValueError(f"{type(layer).__name__} doesn't support DoRA yet.")
             LoRALayer = LoRASwitchLinear
         else:
-            raise ValueError(f"Can't convert layer of type {type(layer)} to LoRA")
+            raise ValueError(
+                f"Can't convert layer of type {type(layer).__name__} to LoRA"
+            )
 
         return LoRALayer.from_linear(
             layer,

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -350,9 +350,13 @@ def load_model(
 
     if (quantization := config.get("quantization", None)) is not None:
         # Handle legacy models which may not have everything quantized
-        class_predicate = lambda p, m: hasattr(m, "to_quantized") and (
-            f"{p}.scales" in weights or f"{p}.up_proj_s" in weights
-        )
+        def class_predicate(p, m):
+            if not hasattr(m, "to_quantized"):
+                return False
+            if hasattr(m, "is_quantized"):
+                return m.is_quantized(weights, p)
+            return f"{p}.scales" in weights
+
         nn.quantize(
             model,
             **quantization,

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -350,9 +350,8 @@ def load_model(
 
     if (quantization := config.get("quantization", None)) is not None:
         # Handle legacy models which may not have everything quantized
-        class_predicate = (
-            lambda p, m: isinstance(m, (nn.Linear, nn.Embedding))
-            and f"{p}.scales" in weights
+        class_predicate = lambda p, m: hasattr(m, "to_quantized") and (
+            f"{p}.scales" in weights or f"{p}.up_proj_s" in weights
         )
         nn.quantize(
             model,

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -353,8 +353,6 @@ def load_model(
         def class_predicate(p, m):
             if not hasattr(m, "to_quantized"):
                 return False
-            if hasattr(m, "is_quantized"):
-                return m.is_quantized(weights, p)
             return f"{p}.scales" in weights
 
         nn.quantize(


### PR DESCRIPTION
Implements all MoEs with the new `mx.block_sparse_mm` and `mx.block_sparse_qmm` (the latter is at https://github.com/ml-explore/mlx/pull/1124 ).

One notable change is in the quantization predicate which accepts modules that define `to_quantized()` and delegates the check for the existence of quantized weights to the module using `is_quantized()`. This allows us to define `SwitchMLP` for each model and a quantized equivalent and auto convert to the quantized one.

### Performance comparison at 4bits

Before
```
Qwen1.5-MoE-A2.7B-Chat     : 56.3 tps
Mixtral-8x7B-Instruct-v0.1 : 40.3 tps
phixtral-4x2_8             : 47.2 tps
```

After
```
Qwen1.5-MoE-A2.7B-Chat     : 121.7 tps
Mixtral-8x7B-Instruct-v0.1 :  59.3 tps
phixtral-4x2_8             :  92.8 tps
```