### PR TITLE
Tweaks to run dspy-produced calls to the server, with gemma template.

### DIFF
--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -51,22 +51,6 @@ def stopping_criteria(
     return StopCondition(stop_met=False, trim_length=0)
 
 
-def fold_in_system_prompt(messages: List[dict]):
-    n = len(messages)
-    if n>0 and messages[0]["role"] == "system":
-        message_system = messages[0]
-        if n>1:
-            message_user = messages[1]
-            assert message_user["role"] == "user"
-            message_user.update(
-                {"content": "System: " + message_system["content"] + "\n" + message_user["content"]}
-            )
-            messages = [message_user] + messages[2:]
-        else:
-            messages_system.update({"role": "user"})
-    return messages
-
-
 def convert_chat(messages: List[dict], role_mapping: Optional[dict] = None):
     default_role_mapping = {
         "system_prompt": "A chat between a curious user and an artificial intelligence assistant. The assistant follows the given rules no matter what.",
@@ -449,11 +433,8 @@ class APIHandler(BaseHTTPRequestHandler):
             hasattr(self.tokenizer, "apply_chat_template")
             and self.tokenizer.chat_template
         ):
-            messages = body["messages"]
-            if "raise_exception('System role not supported')" in self.tokenizer.chat_template:
-                messages = fold_in_system_prompt(messages)
             prompt = self.tokenizer.apply_chat_template(
-                messages,
+                body["messages"],
                 tokenize=True,
                 add_generation_prompt=True,
             )

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -544,6 +544,13 @@ def main():
         required=False,
     )
     parser.add_argument(
+        "--chat-template",
+        type=str,
+        default="",
+        help="Specify a chat template for the tokenizer",
+        required=False,
+    )
+    parser.add_argument(
         "--use-default-chat-template",
         action="store_true",
         help="Use the default chat template",
@@ -566,6 +573,8 @@ def main():
 
     # Building tokenizer_config
     tokenizer_config = {"trust_remote_code": True if args.trust_remote_code else None}
+    if args.chat_template:
+        tokenizer_config['chat_template'] = args.chat_template
 
     model, tokenizer = load(
         args.model, adapter_path=args.adapter_path, tokenizer_config=tokenizer_config

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -60,7 +60,7 @@ def openai_to_common_denominator(messages: List[dict]):
         if t_messages == [] or t_messages[-1]["role"] != m["role"]:
             t_messages.append(m)
         else:
-            t_messages[-1]["content"] = "\n" + m["content"]
+            t_messages[-1]["content"] += "\n" + m["content"]
     return t_messages
 
 

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -187,20 +187,14 @@ class APIHandler(BaseHTTPRequestHandler):
         if not isinstance(self.max_tokens, int) or self.max_tokens < 0:
             raise ValueError("max_tokens must be a non-negative integer")
 
-        if isinstance(self.temperature, int):
-            self.temperature = float(self.temperature)
-        if not isinstance(self.temperature, float) or self.temperature < 0:
+        if not isinstance(self.temperature, (float, int)) or self.temperature < 0:
             raise ValueError("temperature must be a non-negative float")
 
-        if isinstance(self.top_p, int):
-            self.top_p = float(self.top_p)
-        if not isinstance(self.top_p, float) or self.top_p < 0 or self.top_p > 1:
+        if not isinstance(self.top_p, (float, int)) or self.top_p < 0 or self.top_p > 1:
             raise ValueError("top_p must be a float between 0 and 1")
 
-        if isinstance(self.repetition_penalty, int):
-            self.top_p = float(self.repetition_penalty)
         if (
-            not isinstance(self.repetition_penalty, float)
+            not isinstance(self.repetition_penalty, (float, int))
             or self.repetition_penalty < 0
         ):
             raise ValueError("repetition_penalty must be a non-negative float")

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -140,7 +140,8 @@ class APIHandler(BaseHTTPRequestHandler):
         self.validate_model_parameters()
 
         # Get stop id sequences, if provided
-        stop_words = self.body.get("stop", [])
+        stop_words = self.body.get("stop")
+        stop_words = stop_words or []
         stop_words = [stop_words] if isinstance(stop_words, str) else stop_words
         stop_id_sequences = [
             self.tokenizer.encode(stop_word, add_special_tokens=False)

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -554,7 +554,7 @@ def main():
     # Building tokenizer_config
     tokenizer_config = {"trust_remote_code": True if args.trust_remote_code else None}
     if args.chat_template:
-        tokenizer_config['chat_template'] = args.chat_template
+        tokenizer_config["chat_template"] = args.chat_template
 
     model, tokenizer = load(
         args.model, adapter_path=args.adapter_path, tokenizer_config=tokenizer_config

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -542,6 +542,11 @@ def main():
         help="Set the MLX cache limit in GB",
         required=False,
     )
+    parser.add_argument(
+        "--use-default-chat-template",
+        action="store_true",
+        help="Use the default chat template",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -559,6 +564,11 @@ def main():
     model, tokenizer = load(
         args.model, adapter_path=args.adapter_path, tokenizer_config=tokenizer_config
     )
+
+    if args.use_default_chat_template:
+        if tokenizer.chat_template is None:
+            tokenizer.chat_template = tokenizer.default_chat_template
+
     run(args.host, args.port, model, tokenizer)
 
 

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -51,6 +51,22 @@ def stopping_criteria(
     return StopCondition(stop_met=False, trim_length=0)
 
 
+def fold_in_system_prompt(messages: List[dict]):
+    n = len(messages)
+    if n>0 and messages[0]["role"] == "system":
+        message_system = messages[0]
+        if n>1:
+            message_user = messages[1]
+            assert message_user["role"] == "user"
+            message_user.update(
+                {"content": "System: " + message_system["content"] + "\n" + message_user["content"]}
+            )
+            messages = [message_user] + messages[2:]
+        else:
+            messages_system.update({"role": "user"})
+    return messages
+
+
 def convert_chat(messages: List[dict], role_mapping: Optional[dict] = None):
     default_role_mapping = {
         "system_prompt": "A chat between a curious user and an artificial intelligence assistant. The assistant follows the given rules no matter what.",
@@ -171,12 +187,18 @@ class APIHandler(BaseHTTPRequestHandler):
         if not isinstance(self.max_tokens, int) or self.max_tokens < 0:
             raise ValueError("max_tokens must be a non-negative integer")
 
+        if isinstance(self.temperature, int):
+            self.temperature = float(self.temperature)
         if not isinstance(self.temperature, float) or self.temperature < 0:
             raise ValueError("temperature must be a non-negative float")
 
+        if isinstance(self.top_p, int):
+            self.top_p = float(self.top_p)
         if not isinstance(self.top_p, float) or self.top_p < 0 or self.top_p > 1:
             raise ValueError("top_p must be a float between 0 and 1")
 
+        if isinstance(self.repetition_penalty, int):
+            self.top_p = float(self.repetition_penalty)
         if (
             not isinstance(self.repetition_penalty, float)
             or self.repetition_penalty < 0
@@ -433,8 +455,11 @@ class APIHandler(BaseHTTPRequestHandler):
             hasattr(self.tokenizer, "apply_chat_template")
             and self.tokenizer.chat_template
         ):
+            messages = body["messages"]
+            if "raise_exception('System role not supported')" in self.tokenizer.chat_template:
+                messages = fold_in_system_prompt(messages)
             prompt = self.tokenizer.apply_chat_template(
-                body["messages"],
+                messages,
                 tokenize=True,
                 add_generation_prompt=True,
             )

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -447,7 +447,8 @@ class APIHandler(BaseHTTPRequestHandler):
             and self.tokenizer.chat_template
         ):
             messages = body["messages"]
-            messages = openai_to_common_denominator(messages)
+            if self.tokenizer.chat_to_common_denominator:
+                messages = openai_to_common_denominator(messages)
             prompt = self.tokenizer.apply_chat_template(
                 messages,
                 tokenize=True,
@@ -547,6 +548,11 @@ def main():
         action="store_true",
         help="Use the default chat template",
     )
+    parser.add_argument(
+        "--chat-to-common-denominator",
+        action="store_true",
+        help="Transform OpenAI incoming messages to fuse server and user role and stricly alternate roles (as required by e.g. Google Gemma)",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -568,6 +574,8 @@ def main():
     if args.use_default_chat_template:
         if tokenizer.chat_template is None:
             tokenizer.chat_template = tokenizer.default_chat_template
+
+    tokenizer.chat_to_common_denominator = args.chat_to_common_denominator
 
     run(args.host, args.port, model, tokenizer)
 


### PR DESCRIPTION
Hi,

I am not sure if that is of general interest, but I thought I'd submit it in case it's useful.

I had to tweak the server a little to get it to interact with dspy following the following comment https://github.com/stanfordnlp/dspy/issues/385#issuecomment-1998939936.

The two tweaks are to (1) relax the validation and convert from int to float as needed, (2) to work around some chat template not taking the system role (such as Google Gemma's chat template).

can try it out with:
```sh
python -m server --model mlx-community/gemma-1.1-7b-it-4bit --port 1143
```
modulo patching the relative imports in server.py
```
-from .tokenizer_utils import TokenizerWrapper
-from .utils import generate_step, load
+from mlx_lm.tokenizer_utils import TokenizerWrapper
+from mlx_lm.utils import generate_step, load
```

and then, ont the dspy side:
```python
import dspy
lm = dspy.OpenAI(model_type="chat", api_base="http://localhost:11434/v1/", api_key="not_needed", max_tokens=250)
lm("hello")
```

Thanks!