### PR TITLE
Correct type annotation of llama.ModelArgs.num_key_value_heads

### DIFF
--- a/llms/mlx_lm/models/llama.py
+++ b/llms/mlx_lm/models/llama.py
@@ -16,7 +16,7 @@ class ModelArgs(BaseModelArgs):
     num_attention_heads: int
     rms_norm_eps: float
     vocab_size: int
-    num_key_value_heads: int = None
+    num_key_value_heads: Optional[int] = None
     attention_bias: bool = False
     mlp_bias: bool = False
     rope_theta: float = 10000


### PR DESCRIPTION
mypy complains about the assigning of value `None` to the field of type `int`.