### PR TITLE
Correct the type annotation of cache in llama.py

### DIFF
--- a/llms/mlx_lm/models/llama.py
+++ b/llms/mlx_lm/models/llama.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Tuple, Union
 import mlx.core as mx
 import mlx.nn as nn
 
-from .base import BaseModelArgs, create_additive_causal_mask, KVCache
+from .base import BaseModelArgs, KVCache, create_additive_causal_mask
 
 
 @dataclass

--- a/llms/mlx_lm/models/llama.py
+++ b/llms/mlx_lm/models/llama.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Tuple, Union
 import mlx.core as mx
 import mlx.nn as nn
 
-from .base import BaseModelArgs, create_additive_causal_mask
+from .base import BaseModelArgs, create_additive_causal_mask, KVCache
 
 
 @dataclass
@@ -73,7 +73,7 @@ class Attention(nn.Module):
         self,
         x: mx.array,
         mask: Optional[mx.array] = None,
-        cache: Optional[Tuple[mx.array, mx.array]] = None,
+        cache: Optional[KVCache] = None,
     ) -> mx.array:
         B, L, D = x.shape
 
@@ -135,7 +135,7 @@ class TransformerBlock(nn.Module):
         self,
         x: mx.array,
         mask: Optional[mx.array] = None,
-        cache: Optional[Tuple[mx.array, mx.array]] = None,
+        cache: Optional[KVCache] = None,
     ) -> mx.array:
         r = self.self_attn(self.input_layernorm(x), mask, cache)
         h = x + r


### PR DESCRIPTION
The source code accesses `cache.offset` and `cache.update_and_fetch`, which belong to `base.KVCache`, so it seems that we should update the type annotation of `cache` from `Tuple[mx.array, mx.array]` into `base.KVCache`.

After doing so, mypy does not longer complain about the type annotation.