### PR TITLE
Fix mypy errors with models/{qwen2,qwen2_moe,startcoder2}.py

### DIFF
--- a/llms/mlx_lm/models/qwen2.py
+++ b/llms/mlx_lm/models/qwen2.py
@@ -52,8 +52,6 @@ class Attention(nn.Module):
         self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=True)
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=False)
 
-        assert args.rope_scaling is not None
-        assert isinstance(args.rope_scaling["factor"], float)
         rope_scale = (
             1 / args.rope_scaling["factor"]
             if args.rope_scaling is not None and args.rope_scaling["type"] == "linear"

--- a/llms/mlx_lm/models/qwen2.py
+++ b/llms/mlx_lm/models/qwen2.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Tuple, Union
 import mlx.core as mx
 import mlx.nn as nn
 
-from .base import BaseModelArgs
+from .base import BaseModelArgs, KVCache
 
 
 @dataclass
@@ -16,7 +16,7 @@ class ModelArgs(BaseModelArgs):
     num_attention_heads: int
     rms_norm_eps: float
     vocab_size: int
-    num_key_value_heads: int = None
+    num_key_value_heads: Optional[int] = None
     rope_theta: float = 1000000
     rope_traditional: bool = False
     rope_scaling: Optional[Dict[str, Union[float, str]]] = None
@@ -41,6 +41,7 @@ class Attention(nn.Module):
 
         dim = args.hidden_size
         self.n_heads = n_heads = args.num_attention_heads
+        assert args.num_key_value_heads is not None
         self.n_kv_heads = n_kv_heads = args.num_key_value_heads
 
         head_dim = args.hidden_size // n_heads
@@ -51,6 +52,8 @@ class Attention(nn.Module):
         self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=True)
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=False)
 
+        assert args.rope_scaling is not None
+        assert isinstance(args.rope_scaling["factor"], float)
         rope_scale = (
             1 / args.rope_scaling["factor"]
             if args.rope_scaling is not None and args.rope_scaling["type"] == "linear"
@@ -67,7 +70,7 @@ class Attention(nn.Module):
         self,
         x: mx.array,
         mask: Optional[mx.array] = None,
-        cache: Optional[Tuple[mx.array, mx.array]] = None,
+        cache: Optional[KVCache] = None,
     ) -> mx.array:
         B, L, D = x.shape
 
@@ -121,7 +124,7 @@ class TransformerBlock(nn.Module):
         self,
         x: mx.array,
         mask: Optional[mx.array] = None,
-        cache: Optional[Tuple[mx.array, mx.array]] = None,
+        cache: Optional[KVCache] = None,
     ) -> mx.array:
         r = self.self_attn(self.input_layernorm(x), mask, cache)
         h = x + r

--- a/llms/mlx_lm/models/starcoder2.py
+++ b/llms/mlx_lm/models/starcoder2.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 import mlx.core as mx
 import mlx.nn as nn
 
-from .base import BaseModelArgs
+from .base import BaseModelArgs, KVCache
 
 
 @dataclass
@@ -43,7 +43,7 @@ class Attention(nn.Module):
         self,
         x: mx.array,
         mask: Optional[mx.array] = None,
-        cache: Optional[Tuple[mx.array, mx.array]] = None,
+        cache: Optional[KVCache] = None,
     ) -> mx.array:
         B, L, D = x.shape
 
@@ -98,7 +98,7 @@ class TransformerBlock(nn.Module):
         self,
         x: mx.array,
         mask: Optional[mx.array] = None,
-        cache: Optional[Tuple[mx.array, mx.array]] = None,
+        cache: Optional[KVCache] = None,
     ) -> mx.array:
         r = self.self_attn(self.input_layernorm(x), mask, cache)
         h = x + r


### PR DESCRIPTION
Before this change, we have

```
❯ mypy \
  --explicit-package-bases \
  --ignore-missing-imports \
. | grep 'qwen2'
llms/mlx_lm/models/qwen2_moe.py:25: error: Incompatible types in assignment (expression has type "None", variable has type "int")  [assignment]
llms/mlx_lm/models/qwen2_moe.py:82: error: "Tuple[Any, Any]" has no attribute "offset"  [attr-defined]
llms/mlx_lm/models/qwen2_moe.py:83: error: "Tuple[Any, Any]" has no attribute "offset"  [attr-defined]
llms/mlx_lm/models/qwen2_moe.py:84: error: "Tuple[Any, Any]" has no attribute "update_and_fetch"  [attr-defined]
llms/mlx_lm/models/qwen2.py:19: error: Incompatible types in assignment (expression has type "None", variable has type "int")  [assignment]
llms/mlx_lm/models/qwen2.py:55: error: Unsupported operand types for / ("int" and "str")  [operator]
llms/mlx_lm/models/qwen2.py:55: note: Right operand is of type "Union[float, str]"
llms/mlx_lm/models/qwen2.py:82: error: "Tuple[Any, Any]" has no attribute "offset"  [attr-defined]
llms/mlx_lm/models/qwen2.py:83: error: "Tuple[Any, Any]" has no attribute "offset"  [attr-defined]
llms/mlx_lm/models/qwen2.py:84: error: "Tuple[Any, Any]" has no attribute "update_and_fetch"  [attr-defined]
```

and 

```
❯ mypy \
  --explicit-package-bases \
  --ignore-missing-imports \
. | grep 'starcoder2'
llms/mlx_lm/models/starcoder2.py:58: error: "Tuple[Any, Any]" has no attribute "offset"  [attr-defined]
llms/mlx_lm/models/starcoder2.py:59: error: "Tuple[Any, Any]" has no attribute "offset"  [attr-defined]
llms/mlx_lm/models/starcoder2.py:60: error: "Tuple[Any, Any]" has no attribute "update_and_fetch"  [attr-defined]
```

After this change, the above errors disappear.

## TODO

Consider change the following dictionary typed field `rope_scaling` into a nested dataclass in a future PR.

```
@dataclass
class ModelArgs(BaseModelArgs):
    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
```