### PR TITLE
 added docstring explanation for  bertenbeddings class in model.py in…

### DIFF
--- a/bert/model.py
+++ b/bert/model.py
@@ -59,6 +59,8 @@ class TransformerEncoder(nn.Module):
 
 
 class BertEmbeddings(nn.Module):
+    """  Constructs the embeddings for the BERT model, consisting of word, position, and token type embeddings."""
+
     def __init__(self, config):
         super().__init__()
         self.word_embeddings = nn.Embedding(config.vocab_size, config.hidden_size)


### PR DESCRIPTION
This change adds a docstring explanation for the class Bertembeddings inside of model.py inside of bert. This is my first open source commit and  I hope this helps!
Signed off by saul Ifshin <saulifshin.cs@gmail.com>