### PR TITLE
Server loads the model on demand from the request

### DIFF
--- a/llms/tests/test_server.py
+++ b/llms/tests/test_server.py
@@ -7,19 +7,24 @@ from mlx_lm.server import APIHandler
 from mlx_lm.utils import load
 
 
+class DummyModelProvider:
+    def __init__(self):
+        HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
+        self.model, self.tokenizer = load(HF_MODEL_PATH)
+
+    def load(self, model):
+        assert model in ["default_model", "chat_model"]
+        return self.model, self.tokenizer
+
+
 class TestServer(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
-
-        cls.model, cls.tokenizer = load(HF_MODEL_PATH)
-
+        cls.model_provider = DummyModelProvider()
         cls.server_address = ("localhost", 0)
         cls.httpd = http.server.HTTPServer(
             cls.server_address,
-            lambda *args, **kwargs: APIHandler(
-                cls.model, cls.tokenizer, *args, **kwargs
-            ),
+            lambda *args, **kwargs: APIHandler(cls.model_provider, *args, **kwargs),
         )
         cls.port = cls.httpd.server_port
         cls.server_thread = threading.Thread(target=cls.httpd.serve_forever)


### PR DESCRIPTION
As title. Basically moves the model loading logic into the `ModelProvider`. The POST handler passes the `requested_model` to the model provider to load that model instead of always using the default one.

It should be completely backwards compatible even wrt to when the default model will be loaded.