### PR TITLE
Example of response generation with optional arguments

### DIFF
--- a/llms/README.md
+++ b/llms/README.md
@@ -38,7 +38,7 @@ To see a description of all the arguments you can do:
 >>> help(generate)
 ```
 
-For a detailed example of response generation with optional arguments, see `mlx_lm/examples/generate_response.py`. 
+Check out the [generation example](https://github.com/ml-explore/mlx-examples/tree/main/llms/mlx_lm/examples/generate_response.py) to see how to use the API in more detail.
 
 The `mlx-lm` package also comes with functionality to quantize and optionally
 upload models to the Hugging Face Hub.

--- a/llms/README.md
+++ b/llms/README.md
@@ -38,6 +38,8 @@ To see a description of all the arguments you can do:
 >>> help(generate)
 ```
 
+For a detailed example of response generation with optional arguments, see `mlx_lm/examples/generate_response.py`. 
+
 The `mlx-lm` package also comes with functionality to quantize and optionally
 upload models to the Hugging Face Hub.
 

--- a/llms/mlx_lm/examples/generate_response.py
+++ b/llms/mlx_lm/examples/generate_response.py
@@ -1,5 +1,4 @@
-from mlx_lm import load, generate
-
+from mlx_lm import generate, load
 
 # Specify the checkpoint
 checkpoint = "mistralai/Mistral-7B-Instruct-v0.3"
@@ -13,9 +12,7 @@ conversation = [{"role": "user", "content": prompt}]
 
 # Transform the prompt into the chat template
 prompt = tokenizer.apply_chat_template(
-    conversation=conversation,
-    tokenize=False,
-    add_generation_prompt=True
+    conversation=conversation, tokenize=False, add_generation_prompt=True
 )
 
 # Specify the maximum number of tokens
@@ -29,7 +26,7 @@ generation_args = {
     "temp": 0.7,
     "repetition_penalty": 1.2,
     "repetition_context_size": 20,
-    "top_p": 0.95
+    "top_p": 0.95,
 }
 
 # Generate a response with the specified settings
@@ -39,5 +36,5 @@ response = generate(
     prompt=prompt,
     max_tokens=max_tokens,
     verbose=verbose,
-    **generation_args
+    **generation_args,
 )

--- a/llms/mlx_lm/examples/generate_response.py
+++ b/llms/mlx_lm/examples/generate_response.py
@@ -1,0 +1,45 @@
+from mlx_lm import load, generate
+
+
+# Specify the checkpoint
+checkpoint = "mlx-community/Mixtral-8x22B-Instruct-v0.1-4bit"
+
+# Load the corresponding model and tokenizer
+model, tokenizer = load(path_or_hf_repo=checkpoint)
+
+# Specify the prompt and conversation history
+prompt = "Why is the sky blue?"
+conversation = [{"role": "user", "content": prompt}]
+
+# Transform the prompt into the chat template
+prompt = tokenizer.apply_chat_template(
+    conversation=conversation,
+    tokenize=False,
+    add_generation_prompt=True
+)
+
+# Specify the maximum number of tokens
+max_tokens = 1_000
+
+# Specify if tokens and timing information will be printed
+verbose = True
+
+# Some optional arguments for causal language model generation
+generation_details = {
+    "temp": 0.7,
+    "repetition_penalty": 1.2,
+    "repetition_context_size": 20,
+    "top_p": 0.95
+}
+
+# Generate a response with the specified settings
+response = generate(
+    model=model,
+    tokenizer=tokenizer,
+    prompt=prompt,
+    max_tokens=max_tokens,
+    verbose=verbose,
+    **generation_details
+)
+
+print(response)

--- a/llms/mlx_lm/examples/generate_response.py
+++ b/llms/mlx_lm/examples/generate_response.py
@@ -2,7 +2,7 @@ from mlx_lm import load, generate
 
 
 # Specify the checkpoint
-checkpoint = "mlx-community/Mixtral-8x22B-Instruct-v0.1-4bit"
+checkpoint = "mistralai/Mistral-7B-Instruct-v0.3"
 
 # Load the corresponding model and tokenizer
 model, tokenizer = load(path_or_hf_repo=checkpoint)
@@ -25,7 +25,7 @@ max_tokens = 1_000
 verbose = True
 
 # Some optional arguments for causal language model generation
-generation_details = {
+generation_args = {
     "temp": 0.7,
     "repetition_penalty": 1.2,
     "repetition_context_size": 20,
@@ -39,7 +39,5 @@ response = generate(
     prompt=prompt,
     max_tokens=max_tokens,
     verbose=verbose,
-    **generation_details
+    **generation_args
 )
-
-print(response)

--- a/llms/mlx_lm/requirements.txt
+++ b/llms/mlx_lm/requirements.txt
@@ -1,6 +1,6 @@
 mlx>=0.14.1
 numpy
-transformers>=4.39.3
+transformers[sentencepiece]>=4.39.3
 protobuf
 pyyaml
 jinja2


### PR DESCRIPTION
The example is meant to extend the [README](https://github.com/a-wozniakowski/mlx-examples/tree/main/llms), whereby it:
- uses a [checkpoint](https://huggingface.co/mlx-community/Mixtral-8x22B-Instruct-v0.1-4bit) from the mlx-community
- loads the model and tokenizer with `load`
- transforms a prompt into a chat template with the `apply_chat_template` method of the tokenizer
- passes optional arguments into `generate`, which show how to control the generation process