### PR TITLE
Add logit soft capping to gemma, and fix precision issues

### DIFF
--- a/llms/mlx_lm/models/gemma2.py
+++ b/llms/mlx_lm/models/gemma2.py
@@ -20,6 +20,10 @@ class ModelArgs(BaseModelArgs):
     num_key_value_heads: int
     rope_theta: float = 10000
     rope_traditional: bool = False
+    attn_logit_softcapping: float = 50.0
+    final_logit_softcapping: float = 30.0
+    query_pre_attn_scalar: float = 144.0
+    
 
 
 class RMSNorm(nn.Module):
@@ -39,15 +43,16 @@ class Attention(nn.Module):
         dim = args.hidden_size
         self.n_heads = n_heads = args.num_attention_heads
         self.n_kv_heads = n_kv_heads = args.num_key_value_heads
+        self.repeats = n_heads // n_kv_heads
         self.head_dim = head_dim = args.head_dim
 
-        self.scale = head_dim**-0.5
+        self.scale=1.0/(args.query_pre_attn_scalar**0.5)
 
         self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=False)
         self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=False)
         self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=False)
         self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=False)
-
+        self.attn_logit_softcapping = args.attn_logit_softcapping
         self.rope = nn.RoPE(
             head_dim,
             traditional=args.rope_traditional,
@@ -61,13 +66,21 @@ class Attention(nn.Module):
         cache: Optional[Tuple[mx.array, mx.array]] = None,
     ) -> mx.array:
         B, L, D = x.shape
-
+        # Detect NaNs in X
+        """if mx.any(mx.isnan(x)):
+            raise ValueError("x has NaNs")
+        else:
+            pass"""
         queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
-
+        # Detect whether each one has a NaN
         # Prepare the queries, keys and values for the attention computation
         queries = queries.reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
         keys = keys.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
         values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        def repeat(a):
+            a = mx.concatenate([mx.expand_dims(a, 2)] * self.repeats, axis=2)
+            return a.reshape([B, self.n_heads, a.shape[3], -1])
+
 
         if cache is not None:
             queries = self.rope(queries, offset=cache.offset)
@@ -76,13 +89,34 @@ class Attention(nn.Module):
         else:
             queries = self.rope(queries)
             keys = self.rope(keys)
+        # Detect whether the queries, keys and values have NaNs
 
-        output = mx.fast.scaled_dot_product_attention(
+        """ output = mx.fast.scaled_dot_product_attention(
             queries, keys, values, scale=self.scale, mask=mask
-        )
-
-        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-        return self.o_proj(output)
+        )"""
+        # Manually implement scaled dot product attention
+        keys, values = map(repeat, (keys, values))
+        scores = (queries * self.scale) @ keys.transpose(0, 1, 3, 2)
+        old_dtype = scores.dtype
+        scores = scores
+        scores /= self.attn_logit_softcapping
+        scores = mx.tanh(scores)
+        scores *= self.attn_logit_softcapping
+        if mask is not None:
+            scores = scores + mask
+        scores = mx.softmax(scores, axis=-1).astype(old_dtype)
+        """if mx.any(mx.isnan(scores)):
+            raise ValueError("scores has NaNs")"""
+        # Detect whether scores has NaNs
+   
+            #print("Scores is good")
+        output = (scores @ values).transpose(0, 2, 1, 3).reshape(B, L, -1)
+        output = self.o_proj(output)
+        """if mx.any(mx.isnan(output)):
+            raise ValueError("output has NaNs")
+        else:
+            pass"""
+        return  output
 
 
 class MLP(nn.Module):
@@ -119,10 +153,20 @@ class TransformerBlock(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Tuple[mx.array, mx.array]] = None,
     ) -> mx.array:
-        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        """if mx.any(mx.isnan(x)):
+            raise ValueError("x has NaNs")"""
+        r = self.self_attn(self.input_layernorm(x.astype(mx.float32)), mask, cache)
+        """if mx.any(mx.isnan(r)):
+            raise ValueError("r has NaNs")"""
         h = x + self.post_attention_layernorm(r)
-        r = self.mlp(self.pre_feedforward_layernorm(h))
+        """if mx.any(mx.isnan(h)):
+            raise ValueError("h has NaNs")"""
+        r = self.mlp(self.pre_feedforward_layernorm(h).astype(mx.float16)).astype(mx.float32)
+        """if mx.any(mx.isnan(r)):
+            raise ValueError("r2 has NaNs")"""
         out = h + self.post_feedforward_layernorm(r)
+        """if mx.any(mx.isnan(out)):
+            raise ValueError("out has NaNs")"""
         return out
 
 
@@ -165,6 +209,7 @@ class Model(nn.Module):
     def __init__(self, args: ModelArgs):
         super().__init__()
         self.model_type = args.model_type
+        self.final_logit_softcapping = args.final_logit_softcapping
         self.model = GemmaModel(args)
         self.args = args
 
@@ -175,6 +220,9 @@ class Model(nn.Module):
     ):
         out = self.model(inputs, cache)
         out = self.model.embed_tokens.as_linear(out)
+        out = out / self.final_logit_softcapping
+        out = mx.tanh(out)
+        out = out * self.final_logit_softcapping
         return out
 
     @property

--- a/llms/mlx_lm/models/gemma2.py
+++ b/llms/mlx_lm/models/gemma2.py
@@ -67,8 +67,6 @@ class Attention(nn.Module):
     ) -> mx.array:
         B, L, D = x.shape
         queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
-        # Detect whether each one has a NaN
-        # Prepare the queries, keys and values for the attention computation
         queries = queries.reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
         keys = keys.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
         values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)


### PR DESCRIPTION
Gemma was talking nonsense - so I figured out it was due to not having logit softcapping and precision issues causing NaNs (so I implemented the softcapping and added more float32 inference). gemma-27b-it-4bit now works flawlessly (or near-flawlessly, no sliding-window attention).

Will post more comparisons later - but right now, try the model available on mlx-community with this pr and the current mlx branch. The difference will be clear (as the current implementation just outputs pad).