### PR TITLE
Adding the get_embeddings method

### DIFF
--- a/llms/mlx_lm/LORA.md
+++ b/llms/mlx_lm/LORA.md
@@ -96,6 +96,16 @@ mlx_lm.generate \
     --prompt "<your_model_prompt>"
 ```
 
+For Embeddings extraction, you simply have to add the `--generate-embeddings` argument:
+
+```shell
+mlx_lm.generate \
+    --model <path_to_model> \
+    --generate-embeddings \
+    --prompt "<your_model_prompt>"
+```
+
+
 ## Fuse
 
 You can generate a model fused with the low-rank adapters using the

--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -4,7 +4,7 @@ import argparse
 
 import mlx.core as mx
 
-from .utils import generate, load
+from .utils import generate, generate_embeddings, load
 
 DEFAULT_MODEL_PATH = "mlx_model"
 DEFAULT_PROMPT = "hello"
@@ -32,6 +32,11 @@ def setup_arg_parser():
         "--trust-remote-code",
         action="store_true",
         help="Enable trusting remote code for tokenizer",
+    )
+    parser.add_argument(
+        "--generate-embeddings",
+        action="store_true",
+        help="Generate the Embeddings from the model",
     )
     parser.add_argument(
         "--eos-token",
@@ -145,16 +150,19 @@ def main():
 
     formatter = colorprint_by_t0 if args.colorize else None
 
-    generate(
-        model,
-        tokenizer,
-        prompt,
-        args.max_tokens,
-        verbose=True,
-        formatter=formatter,
-        temp=args.temp,
-        top_p=args.top_p,
-    )
+    if generate_embeddings:
+        generate_embeddings(model, tokenizer, prompt)
+    else:
+        generate(
+            model,
+            tokenizer,
+            prompt,
+            args.max_tokens,
+            verbose=True,
+            formatter=formatter,
+            temp=args.temp,
+            top_p=args.top_p,
+        )
 
 
 if __name__ == "__main__":

--- a/llms/mlx_lm/models/cohere.py
+++ b/llms/mlx_lm/models/cohere.py
@@ -178,6 +178,9 @@ class Model(nn.Module):
         self.model = CohereModel(args)
         self.args = args
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.model.embed_tokens(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/dbrx.py
+++ b/llms/mlx_lm/models/dbrx.py
@@ -222,6 +222,9 @@ class Model(nn.Module):
         self.lm_head = nn.Linear(args.d_model, args.vocab_size, bias=False)
         self.args = args
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.transformer.wte(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/gemma.py
+++ b/llms/mlx_lm/models/gemma.py
@@ -162,6 +162,9 @@ class Model(nn.Module):
         self.model = GemmaModel(args)
         self.args = args
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.model.embed_tokens(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/gemma2.py
+++ b/llms/mlx_lm/models/gemma2.py
@@ -187,6 +187,9 @@ class Model(nn.Module):
         self.model = GemmaModel(args)
         self.args = args
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.model.embed_tokens(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/gpt2.py
+++ b/llms/mlx_lm/models/gpt2.py
@@ -157,6 +157,9 @@ class Model(nn.Module):
         self.model_type = args.model_type
         self.model = GPT2Model(args)
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.model.wte(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/gpt_bigcode.py
+++ b/llms/mlx_lm/models/gpt_bigcode.py
@@ -170,6 +170,9 @@ class Model(nn.Module):
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.n_embd, args.vocab_size, bias=False)
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.transformer.wte(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/internlm2.py
+++ b/llms/mlx_lm/models/internlm2.py
@@ -173,6 +173,9 @@ class Model(nn.Module):
         if not args.tie_word_embeddings:
             self.output = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.model.tok_embeddings(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/llama.py
+++ b/llms/mlx_lm/models/llama.py
@@ -189,6 +189,9 @@ class Model(nn.Module):
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.model.embed_tokens(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/minicpm.py
+++ b/llms/mlx_lm/models/minicpm.py
@@ -184,6 +184,9 @@ class Model(nn.Module):
         if not self.args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.model.embed_tokens(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/mixtral.py
+++ b/llms/mlx_lm/models/mixtral.py
@@ -187,6 +187,9 @@ class Model(nn.Module):
         self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
         self.args = args
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.model.embed_tokens(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/olmo.py
+++ b/llms/mlx_lm/models/olmo.py
@@ -150,6 +150,9 @@ class OlmoModel(nn.Module):
         super().__init__()
         self.transformer = Transformer(args)
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.transformer.wte(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/openelm.py
+++ b/llms/mlx_lm/models/openelm.py
@@ -203,6 +203,9 @@ class Model(nn.Module):
         if not args.share_input_output_layers:
             self.lm_head = nn.Linear(args.model_dim, args.vocab_size, bias=False)
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.transformer.token_embeddings(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/phi.py
+++ b/llms/mlx_lm/models/phi.py
@@ -159,6 +159,9 @@ class Model(nn.Module):
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=True)
         self.args = config
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.model.embed_tokens(inputs)
+
     def __call__(
         self,
         x: mx.array,

--- a/llms/mlx_lm/models/phi3.py
+++ b/llms/mlx_lm/models/phi3.py
@@ -194,6 +194,9 @@ class Model(nn.Module):
         self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
         self.args = args
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.model.embed_tokens(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/phixtral.py
+++ b/llms/mlx_lm/models/phixtral.py
@@ -161,6 +161,9 @@ class Model(nn.Module):
         self.lm_head = OutputHead(config)
         self.args = config
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.transformer.embd(inputs)
+
     def __call__(
         self,
         x: mx.array,

--- a/llms/mlx_lm/models/plamo.py
+++ b/llms/mlx_lm/models/plamo.py
@@ -195,6 +195,9 @@ class Model(nn.Module):
         )
         self.args = args
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.model.embed_tokens(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/qwen.py
+++ b/llms/mlx_lm/models/qwen.py
@@ -147,6 +147,9 @@ class Model(nn.Module):
         )
         self.args = config
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.transformer.wte(inputs)
+
     def __call__(
         self,
         x: mx.array,

--- a/llms/mlx_lm/models/qwen2.py
+++ b/llms/mlx_lm/models/qwen2.py
@@ -174,6 +174,9 @@ class Model(nn.Module):
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.model.embed_tokens(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/qwen2_moe.py
+++ b/llms/mlx_lm/models/qwen2_moe.py
@@ -211,6 +211,9 @@ class Model(nn.Module):
         self.model = Qwen2MoeModel(args)
         self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.model.embed_tokens(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/models/stablelm.py
+++ b/llms/mlx_lm/models/stablelm.py
@@ -192,6 +192,9 @@ class Model(nn.Module):
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
         self.args = config
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.model.embed_tokens(inputs)
+
     def __call__(
         self,
         x: mx.array,

--- a/llms/mlx_lm/models/starcoder2.py
+++ b/llms/mlx_lm/models/starcoder2.py
@@ -150,6 +150,9 @@ class Model(nn.Module):
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
 
+    def get_input_embeddings(self, inputs: mx.array):
+        return self.model.embed_tokens(inputs)
+
     def __call__(
         self,
         inputs: mx.array,

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -263,6 +263,27 @@ def stream_generate(
     detokenizer.finalize()
     yield detokenizer.last_segment
 
+def generate_embeddings(
+    model: nn.Module,
+    tokenizer: Union[PreTrainedTokenizer, TokenizerWrapper],
+    text: str,
+) -> mx.array:
+    """
+    Generate the Embeddings based on the input tones from the model.
+
+    Args:
+       model (nn.Module): The language model.
+       tokenizer (PreTrainedTokenizer): The tokenizer.
+       text (str): The string prompt.
+    """
+    if not isinstance(tokenizer, TokenizerWrapper):
+        tokenizer = TokenizerWrapper(tokenizer)
+
+    text_tokens = mx.array(tokenizer.encode(text))
+
+    output_embedings = model.get_input_embeddings(text_tokens)
+    print(f"Generated Embeddings:\n{output_embedings}")
+    return output_embedings
 
 def generate(
     model: nn.Module,


### PR DESCRIPTION
Added the `get_input_embeddings` method to the LLM codebases. The purpose of this method is to provide direct access to the input embeddings, offering several key benefits:

### Custom Processing:
- Allows for custom operations or transformations on embeddings before they proceed to subsequent layers, enhancing flexibility.
 
### Feature Extraction:
- Enables the extraction of embeddings for downstream tasks like clustering or classification without retraining the entire model, particularly useful with pre-trained models.

### (maybe future plans) Transfer Learning:
- For selective fine-tuning of certain layers or embeddings during transfer learning.

### Facilitates Experimentation:
- Supports research and development efforts by enabling straightforward experimentation with different types of embeddings and embedding spaces.

if the `--generate-embeddings` argument is not added, it will then generate normally.

```sh
python -m mlx_lm.generate \
    --model model_name \
    --generate-embeddings \
    --prompt "This is a input"
```

will return the embeddings for future processing and prints them out too.

```text
Generated Embeddings:
array([[0, 0, -0.116699, ..., 0.0473633, 0.0952148, -0.0473633],
       [0.109375, -0.0218506, 0.0218506, ..., -0.0449219, 0, -0.0672607],
       [-0.0712891, -0.0712891, 0, ..., 0, -0.0996094, 0.0500488],
       [0.0615234, 0.0615234, 0, ..., -0.0529785, 0.0529785, 0],
       [-0.0288696, 0.0481567, -0.0673828, ..., 0, -0.0219116, 0.0109863]], dtype=float16)
```