### PR TITLE
Validation with full data set, results in NaN validation score

### DIFF
--- a/lora/lora.py
+++ b/lora/lora.py
@@ -223,7 +223,7 @@ def evaluate(model, dataset, loss, tokenizer, batch_size, num_batches):
 
     # num_batches can be -1 to indicate the entire set
     index_iterator = iter(range(num_batches)) if num_batches != -1 else iter(int, 1)
-        
+
     for it, batch in zip(
         index_iterator,
         iterate_batches(dataset, tokenizer, batch_size),

--- a/lora/lora.py
+++ b/lora/lora.py
@@ -221,12 +221,11 @@ def evaluate(model, dataset, loss, tokenizer, batch_size, num_batches):
     all_losses = []
     ntokens = 0
 
-    # CLI arguments may set num_batches to -1; if so, find the true count
-    if num_batches == -1:
-        num_batches = len(dataset)
+    # num_batches can be -1 to indicate the entire set
+    index_iterator = iter(range(num_batches)) if num_batches != -1 else iter(int, 1)
         
     for it, batch in zip(
-        range(num_batches),
+        index_iterator,
         iterate_batches(dataset, tokenizer, batch_size),
     ):
         losses, toks = loss(model, *batch)

--- a/lora/lora.py
+++ b/lora/lora.py
@@ -220,6 +220,11 @@ def iterate_batches(dset, tokenizer, batch_size, train=False):
 def evaluate(model, dataset, loss, tokenizer, batch_size, num_batches):
     all_losses = []
     ntokens = 0
+
+    # CLI arguments may set num_batches to -1; if so, find the true count
+    if num_batches == -1:
+        num_batches = len(dataset)
+        
     for it, batch in zip(
         range(num_batches),
         iterate_batches(dataset, tokenizer, batch_size),


### PR DESCRIPTION
## Problem

The CLI arguments allow you to validate with the entire dataset by passing a negative one value, but this quickly results in a division by zero `NaN` to appear as the validation score!

## Expected Behavior

Using `-1` for the `--val-batches` argument should run the validation process using all available mini batches from the dataset.

## Observed Behavior

Upon starting a `--train` with `--val-batches -1`, the process quickly kicks back a `NaN` for the validation score!

## Proposed Remedy

Check if the `--val-batches` got a `-1` and if so, re-assign it to be the complete size of the data (validation) set.

## Testing

I tested this two-line change locally and it works.

## Why

* I have learned that `mlx_lm` offers more (in the sibling directory of this repo), although I still found the study of this file helpful.
* I was doing a "memorization" training, such that `train.jsonl` had the full dataset, `valid.jsonl` had the full dataset, and the "test" phase (with `test.jsonl`) is discarded. This way, the chat model is completely memorizing the source data.