### PR TITLE
Add a method for matching model parameters inputted in command line and HTTP requests

### DIFF
--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -115,8 +115,10 @@ class ModelProvider:
         }
         if self.cli_args.chat_template:
             tokenizer_config["chat_template"] = self.cli_args.chat_template
-
-        if model_path == "default_model" and self.cli_args.model is not None:
+        inputed_model_path = Path(self.cli_args.model)
+        if (model_path == "default_model" and self.cli_args.model is not None) or (
+            inputed_model_path.name == model_path
+        ):
             model, tokenizer = load(
                 self.cli_args.model,
                 adapter_path=self.cli_args.adapter_path,


### PR DESCRIPTION
Hi there. When I want to use mlx_lm.server to load a local model as a service, I need to run the command:

```
python -m mlx_lm.server --model /works/huggingface.co/mlx-community/dolphin-2.9-llama3-70b-4bit --host 0.0.0.0 --port 9001
```
After that, I make HTTP requests using the curl command:

```
curl localhost:9001/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
     "messages": [{"role": "user", "content": "hi there"}]
   }'
```
Everything runs fine up to this point.

However, when I need to make requests using [LibreChat](https://github.com/danny-avila/LibreChat), I found that the HTTP request body structure is as follows:

```json
{
	"model": "dolphin-2.9-llama3-70b-4bit",
	"temperature": 0.2,
	"top_p": 1,
	"presence_penalty": 0,
	"frequency_penalty": 0,
	"stop": [
		""
	],
	"max_tokens": 8000,
	"user": "6693bd66cf55a62392ffe31c",
	"messages": [
		{
			"role": "user",
			"content": "hi there"
		}
	]
}
```
The model parameter in the body causes the ***model_path*** in the ***load*** method of the ***ModelProvider*** class in ***server.py*** to be set to "dolphin-2.9-llama3-70b-4bit" instead of "default_model". [server.py L119-L127](https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/server.py#L119-L127)

I've carefully reviewed the code and understand that this design allows for downloading the model directly from HuggingFace if it doesn't exist locally. However, if the local model exists, it doesn't match, triggering a download again.

To address this, I have added a check: if the model parameter specified in the HTTP request matches the model parameter ***Path.name*** specified when starting mlx_lm.server (server.py) (i.e., if the local model folder name matches the requested model name), then prioritize using the local model rather than downloading it from HuggingFace.