### PR TITLE
Keep the LM server in a valid state

### DIFF
--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -108,6 +108,7 @@ class ModelProvider:
         # Remove the old model if it exists.
         self.model = None
         self.tokenizer = None
+        self.model_key = None
 
         # Building tokenizer_config
         tokenizer_config = {


### PR DESCRIPTION
Fixes #887 

If a model is loaded, then you load an invalid model and then reload the old model, the key is not updated.. so it thinks it has the old model correctly loaded even though the model and tokenizer were cleared.