### PR TITLE
Introducing `--resume-training` to preserve adapter files from being overwritten

### DIFF
--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -176,7 +176,7 @@ def train_model(
     linear_to_lora_layers(model, args.lora_layers, args.lora_parameters, args.use_dora)
 
     # Resume training the given adapters.
-    if (args.resume_adapter_file and args.resume_training) is not None:
+    if args.resume_adapter_file is not None and args.resume_training:
         raise ValueError(
             "Invalid Arguments: Please select either `--resume-adapter-file` or `--resume-training`, avoid both."
         )


### PR DESCRIPTION
Instead of trying to illustrate some undesirable behavior from `--resume-adapter-file` as a bug, I've decided to share `--resume-training` to meet my needs.

## New Feature Synopsis
This enabled `--resume-training` argument is an alternative to `--resume-adapter-file` and allows the program to continue where it left off, by selecting the highest integer valued checkpoint found in the `--adapters-path`.

After the program hits `9999999`, it should halt, and give the user some instruction on how to resume training if they so desire.

The program will refuse to start if both `--resume-adapter-file` **and** `--resume-training` are supplied, since `--resume-training` fills in the spot utilized by `--resume-adapter-file`.  The feature is accomplished by adding an `adapters_found_count` to the `TrainingArguments` class, and this offset is summed with the `it` iterations count during the training loop to determine the next filename.

### Backwards Compatibility
This feature is completely compatible, it should not change the existing function of the program.  When `--resume-adapter-file` is used this new feature should remain unnoticed.

## Example

`python -m mlx_lm.lora --train --adapter-path /My/Adapter/Path --resume-training ...` 

**EXCLUSIVE OR**

`python -m mlx_lm.lora --train --adapter-path /My/Adapter/Path --resume-adapter-file /My/Favorite/adapters.safetensors ...`

## Why
During my learning I am trying to establish metrics (objective and subjective) between checkpoints: otherwise one has to bother with managing directories, else, the checkpoints are overwritten when the training process is restarted.

## Testing
I tested locally, with `--save-every` set to `25`, and restarting a few times works: `--resume-training` finds the correct last `XXXXXXX_adapters.safetensors` file, and continues writing higher-numbered files until complete.

## Todo
* Style? I'm new here, I tried to emulate the style you guys were using (`is not None`, for example); feel free to re-organize the logic (or ask me to).
* Perceived impact: am I an edge case?
* Wiki documentation? Examples? Will this new feature add **confusion** to any docs or examples?
* Are there unit tests? I have not ran (or looked for) any tests here. Does this break any of the tests if they exist?

## Remarks
Thank you for keeping this project inclusive! This original code, documentation and PR was done by hand (without generative AI). 😎