### PR TITLE
Adapters loading

### DIFF
--- a/llms/mlx_lm/SERVER.md
+++ b/llms/mlx_lm/SERVER.md
@@ -78,3 +78,10 @@ curl localhost:8080/v1/chat/completions \
 - `logprobs`: (Optional) An integer specifying the number of top tokens and
   corresponding log probabilities to return for each output in the generated
   sequence. If set, this can be any value between 1 and 10, inclusive.
+
+- `model`: (Optional) A string path to a local model or Hugging Face repo id.
+  If the path is local is must be relative to the directory the server was
+  started in.
+
+- `adapters`: (Optional) A string path to low-rank adapters. The path must be
+  rlative to the directory the server was started in.

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -103,7 +103,7 @@ class ModelProvider:
 
     # Added in adapter_path to load dynamically
     def load(self, model_path, adapter_path=None):
-        if self.model_key == model_path:
+        if self.model_key == (model_path, adapter_path):
             return self.model, self.tokenizer
 
         # Remove the old model if it exists.
@@ -136,7 +136,7 @@ class ModelProvider:
             if tokenizer.chat_template is None:
                 tokenizer.chat_template = tokenizer.default_chat_template
 
-        self.model_key = model_path
+        self.model_key = (model_path, adapter_path)
         self.model = model
         self.tokenizer = tokenizer
 
@@ -201,7 +201,7 @@ class APIHandler(BaseHTTPRequestHandler):
         # Extract request parameters from the body
         self.stream = self.body.get("stream", False)
         self.requested_model = self.body.get("model", "default_model")
-        self.adapter = self.body.get("adapter-path", None)
+        self.adapter = self.body.get("adapters", None)
         self.max_tokens = self.body.get("max_tokens", 100)
         self.temperature = self.body.get("temperature", 1.0)
         self.top_p = self.body.get("top_p", 1.0)

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -100,8 +100,9 @@ class ModelProvider:
             raise RuntimeError(
                 "Local models must be relative to the current working dir."
             )
-
-    def load(self, model_path):
+        
+    #Added in adapter_path to load dynamically 
+    def load(self, model_path, adapter_path=None):
         if self.model_key == model_path:
             return self.model, self.tokenizer
 
@@ -120,12 +121,12 @@ class ModelProvider:
         if model_path == "default_model" and self.cli_args.model is not None:
             model, tokenizer = load(
                 self.cli_args.model,
-                adapter_path=self.cli_args.adapter_path,
+                adapter_path= adapter_path if adapter_path else self.cli_args.adapter_path, #if the user doesn't change the model but adds an adapter path
                 tokenizer_config=tokenizer_config,
             )
         else:
             self._validate_model_path(model_path)
-            model, tokenizer = load(model_path, tokenizer_config=tokenizer_config)
+            model, tokenizer = load(model_path, adapter_path=adapter_path, tokenizer_config=tokenizer_config)
 
         if self.cli_args.use_default_chat_template:
             if tokenizer.chat_template is None:
@@ -196,6 +197,7 @@ class APIHandler(BaseHTTPRequestHandler):
         # Extract request parameters from the body
         self.stream = self.body.get("stream", False)
         self.requested_model = self.body.get("model", "default_model")
+        self.adapter = self.body.get("adapter-path", None)
         self.max_tokens = self.body.get("max_tokens", 100)
         self.temperature = self.body.get("temperature", 1.0)
         self.top_p = self.body.get("top_p", 1.0)
@@ -207,7 +209,7 @@ class APIHandler(BaseHTTPRequestHandler):
 
         # Load the model if needed
         try:
-            self.model, self.tokenizer = self.model_provider.load(self.requested_model)
+            self.model, self.tokenizer = self.model_provider.load(self.requested_model, self.adapter)
         except:
             self._set_completion_headers(404)
             self.end_headers()
@@ -281,6 +283,8 @@ class APIHandler(BaseHTTPRequestHandler):
 
         if not isinstance(self.requested_model, str):
             raise ValueError("model must be a string")
+        if self.adapter is not None and not isinstance(self.adapter, str):
+            raise ValueError("adapter must be a string")
 
     def generate_response(
         self,

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -100,8 +100,8 @@ class ModelProvider:
             raise RuntimeError(
                 "Local models must be relative to the current working dir."
             )
-        
-    #Added in adapter_path to load dynamically 
+
+    # Added in adapter_path to load dynamically
     def load(self, model_path, adapter_path=None):
         if self.model_key == model_path:
             return self.model, self.tokenizer
@@ -121,12 +121,16 @@ class ModelProvider:
         if model_path == "default_model" and self.cli_args.model is not None:
             model, tokenizer = load(
                 self.cli_args.model,
-                adapter_path= adapter_path if adapter_path else self.cli_args.adapter_path, #if the user doesn't change the model but adds an adapter path
+                adapter_path=(
+                    adapter_path if adapter_path else self.cli_args.adapter_path
+                ),  # if the user doesn't change the model but adds an adapter path
                 tokenizer_config=tokenizer_config,
             )
         else:
             self._validate_model_path(model_path)
-            model, tokenizer = load(model_path, adapter_path=adapter_path, tokenizer_config=tokenizer_config)
+            model, tokenizer = load(
+                model_path, adapter_path=adapter_path, tokenizer_config=tokenizer_config
+            )
 
         if self.cli_args.use_default_chat_template:
             if tokenizer.chat_template is None:
@@ -209,7 +213,9 @@ class APIHandler(BaseHTTPRequestHandler):
 
         # Load the model if needed
         try:
-            self.model, self.tokenizer = self.model_provider.load(self.requested_model, self.adapter)
+            self.model, self.tokenizer = self.model_provider.load(
+                self.requested_model, self.adapter
+            )
         except:
             self._set_completion_headers(404)
             self.end_headers()

--- a/llms/tests/test_server.py
+++ b/llms/tests/test_server.py
@@ -12,7 +12,7 @@ class DummyModelProvider:
         HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
         self.model, self.tokenizer = load(HF_MODEL_PATH)
 
-    def load(self, model):
+    def load(self, model, adapter=None):
         assert model in ["default_model", "chat_model"]
         return self.model, self.tokenizer
 


### PR DESCRIPTION
Right now to add in adapters once the server has started, we need to restart the server. I just minimally changed the ```load``` function and the ```do_POST``` function in server.py, adding in an optional argument to load so that the user can add in an adapter during runtime. I tested it with by starting a server with Mistral and then changing the model to Phi-3B w/ LoRa adapters with a POST request.


**I did not add the restriction that adapters need to be in the current working directory **