### PR TITLE
Server: support stream_options

### DIFF
--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -6,16 +6,12 @@ import logging
 import time
 import uuid
 import warnings
-from functools import lru_cache
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import Dict, List, Literal, NamedTuple, Optional, Tuple, Union
+from typing import Dict, List, Literal, NamedTuple, Optional, Union
 
 import mlx.core as mx
-import mlx.nn as nn
-from transformers import PreTrainedTokenizer
 
-from .tokenizer_utils import TokenizerWrapper
 from .utils import generate_step, load
 
 
@@ -195,6 +191,7 @@ class APIHandler(BaseHTTPRequestHandler):
 
         # Extract request parameters from the body
         self.stream = self.body.get("stream", False)
+        self.stream_options = self.body.get("stream_options", None)
         self.requested_model = self.body.get("model", "default_model")
         self.max_tokens = self.body.get("max_tokens", 100)
         self.temperature = self.body.get("temperature", 1.0)
@@ -525,8 +522,32 @@ class APIHandler(BaseHTTPRequestHandler):
             self.wfile.write(f"data: {json.dumps(response)}\n\n".encode())
             self.wfile.flush()
 
+        if self.stream_options["include_usage"]:
+            response = self.completion_usage_response(len(prompt), len(tokens))
+            self.wfile.write(f"data: {json.dumps(response)}\n\n".encode())
+
         self.wfile.write("data: [DONE]\n\n".encode())
         self.wfile.flush()
+
+    def completion_usage_response(
+        self,
+        prompt_token_count: Optional[int] = None,
+        completion_token_count: Optional[int] = None,
+    ):
+        response = {
+            "id": self.request_id,
+            "system_fingerprint": f"fp_{uuid.uuid4()}",
+            "object": self.object_type,
+            "model": self.requested_model,
+            "created": self.created,
+            "choices": [],
+            "usage": {
+                "prompt_tokens": prompt_token_count,
+                "completion_tokens": completion_token_count,
+                "total_tokens": prompt_token_count + completion_token_count,
+            },
+        }
+        return response
 
     def handle_chat_completions(self) -> mx.array:
         """

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -537,7 +537,7 @@ class APIHandler(BaseHTTPRequestHandler):
         response = {
             "id": self.request_id,
             "system_fingerprint": f"fp_{uuid.uuid4()}",
-            "object": self.object_type,
+            "object": "chat.completion",
             "model": self.requested_model,
             "created": self.created,
             "choices": [],

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -522,7 +522,7 @@ class APIHandler(BaseHTTPRequestHandler):
             self.wfile.write(f"data: {json.dumps(response)}\n\n".encode())
             self.wfile.flush()
 
-        if self.stream_options["include_usage"]:
+        if self.stream_options is not None and self.stream_options["include_usage"]:
             response = self.completion_usage_response(len(prompt), len(tokens))
             self.wfile.write(f"data: {json.dumps(response)}\n\n".encode())
 


### PR DESCRIPTION

Usage stats are now available when using streaming in the Chat Completions API. Set `stream_options: {"include_usage": true}` and you’ll see an extra chunk at the end of the stream with usage populated.

![image](https://github.com/user-attachments/assets/0f81d47b-ea13-427c-b1ed-6e3b1d3d24b9)

- twitter/x: https://x.com/OpenAIDevs/status/1787573348496773423
- cookbook: https://cookbook.openai.com/examples/how_to_stream_completions#4-how-to-get-token-usage-data-for-streamed-chat-completion-response
- api docs: https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream_options


use
```bash
curl http://localhost:8080/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model": "Qwen/Qwen2-0.5B-Instruct-MLX",
        "stream":true,
        "stream_options":{"include_usage":true},
        "messages": [
            {
                "role": "system",
                "content": "You are a helpful assistant."
            },
            {
                "role": "user",
                "content": "Hello!"
            }
        ]
    }'
```

response:
```
data: {"id": "chatcmpl-b12aabdb-76a0-4949-9569-7cd95bcb1b3b", "system_fingerprint": "fp_38939e6c-15e5-4f71-9b3d-793c7dd18c55", "object": "chat.completions.chunk", "model": "Qwen/Qwen2-0.5B-Instruct-MLX", "created": 1721927969, "choices": [{"index": 0, "logprobs": {"token_logprobs": [], "top_logprobs": [], "tokens": null}, "finish_reason": null, "delta": {"role": "assistant", "content": ""}}]}

data: {"id": "chatcmpl-b12aabdb-76a0-4949-9569-7cd95bcb1b3b", "system_fingerprint": "fp_67292159-0a46-4809-beb2-3fd331b573f9", "object": "chat.completion", "model": "Qwen/Qwen2-0.5B-Instruct-MLX", "created": 1721927969, "choices": [], "usage": {"prompt_tokens": 21, "completion_tokens": 10, "total_tokens": 31}}

data: [DONE]
```