### PR TITLE
Fix whipser conversion for safetensors models

### DIFF
--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -660,6 +660,16 @@ def convert(
     revision: Optional[str] = None,
     dequantize: bool = False,
 ):
+    # Check the save path is empty
+    if isinstance(mlx_path, str):
+        mlx_path = Path(mlx_path)
+
+    if mlx_path.exists():
+        raise ValueError(
+            f"Cannot save to the path {mlx_path} as it already exists."
+            " Please delete the file/directory or specify a new path to save to."
+        )
+
     print("[INFO] Loading")
     model_path = get_model_path(hf_path, revision=revision)
     model, config, tokenizer = fetch_from_hub(model_path, lazy=True)
@@ -680,9 +690,6 @@ def convert(
         print("[INFO] Dequantizing")
         model = dequantize_model(model)
         weights = dict(tree_flatten(model.parameters()))
-
-    if isinstance(mlx_path, str):
-        mlx_path = Path(mlx_path)
 
     del model
     save_weights(mlx_path, weights, donate_weights=True)

--- a/llms/tests/test_utils.py
+++ b/llms/tests/test_utils.py
@@ -82,6 +82,7 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(isinstance(model.layers[-1].mlp.up_proj, nn.QuantizedLinear))
 
         # Check model weights have right type
+        mlx_path = os.path.join(self.test_dir, "mlx_model_bf16")
         utils.convert(HF_MODEL_PATH, mlx_path=mlx_path, dtype="bfloat16")
         model, _ = utils.load(mlx_path)
 


### PR DESCRIPTION
A couple minor fixes here:

- Fix whisper conversion for safetensors models
- Change MLX LM to throw if the save path already exists. This has caused subtle bugs in the past where we overwrite parts of existing models and then end up loading from an invalid model directory. So that is no longer possible (Relevant issue #934)