### PR TITLE
feat(mlx_lm): basic speculative decoding support in mlx_lm.generate / mlx_lm.server

### DIFF
--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -24,6 +24,12 @@ def setup_arg_parser():
         help="The path to the local model directory or Hugging Face repo.",
     )
     parser.add_argument(
+        "--draft-model",
+        type=str,
+        required=False,
+        help="The path to the local model directory or Hugging Face repo for speculative decoding.",
+    )
+    parser.add_argument(
         "--adapter-path",
         type=str,
         help="Optional path for the trained adapter weights and config.",
@@ -81,7 +87,7 @@ def setup_arg_parser():
         "--max-kv-size",
         type=int,
         default=1024,
-        help="Set the maximum key-value cache size",
+        help="Set the maximum key-value cache size (0 for unlimited)",
     )
     return parser
 
@@ -132,6 +138,7 @@ def main():
         adapter_path=args.adapter_path,
         tokenizer_config=tokenizer_config,
     )
+    draft_model = load(args.draft_model)[0] if args.draft_model is not None else None
 
     if args.use_default_chat_template:
         if tokenizer.chat_template is None:
@@ -159,7 +166,8 @@ def main():
         formatter=formatter,
         temp=args.temp,
         top_p=args.top_p,
-        max_kv_size=args.max_kv_size,
+        max_kv_size=args.max_kv_size if args.max_kv_size > 0 else None,
+        draft_model=draft_model,
     )
 
 

--- a/llms/mlx_lm/sample_utils.py
+++ b/llms/mlx_lm/sample_utils.py
@@ -26,7 +26,10 @@ def min_p_sampling(
             0.99-0.8 range.
         min_tokens_to_keep (int, optional): Minimum number of tokens that cannot
             be filtered. Default: ``1``.
-
+        temperature: Temperature parameter for softmax distribution reshaping.
+    Returns:
+        token(s) selected based on the min-p criterion.
+        Shape: same as logits, but with the last dimension having size 1.
     """
     if not (0 <= min_p <= 1.0):
         raise ValueError(
@@ -39,14 +42,14 @@ def min_p_sampling(
     # reference implementation: https://github.com/huggingface/transformers/blob/main/src/transformers/generation/logits_process.py#L531-L605
 
     # Softmax probabilities
-    probs = mx.softmax(logits * (1 / temperature), axis=-1)
+    probs = mx.softmax(logits / temperature, axis=-1)
 
     # Indices sorted in decreasing order
-    sorted_indices = mx.argsort(-logits).squeeze(0)
-    sorted_probs = probs[..., sorted_indices]
+    sorted_indices = mx.argsort(-logits)
+    sorted_probs = mx.take_along_axis(probs, sorted_indices, axis=-1)
 
     # Top probability
-    top_probs = probs[..., sorted_indices[0]]
+    top_probs = mx.expand_dims(sorted_probs[..., 0], axis=-1)
 
     # Calculate the min_p threshold
     scaled_min_p = min_p * top_probs
@@ -58,13 +61,18 @@ def min_p_sampling(
     # Create pool of tokens with probability less than scaled min_p
     selected_probs = mx.where(tokens_to_remove, 0, sorted_probs)
 
-    # Return sampled token
-    sorted_token = mx.random.categorical(mx.log(selected_probs))
-    return sorted_indices[sorted_token]
+    # Return sampled token(s)
+    sampled_indices = mx.random.categorical(mx.log(selected_probs))
+    tokens = mx.take_along_axis(
+        sorted_indices, mx.expand_dims(sampled_indices, axis=-1), axis=-1
+    )
+    return tokens.squeeze(-1)
 
 
 @partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
-def top_p_sampling(logits: mx.array, top_p: float, temperature: float) -> mx.array:
+def top_p_sampling(
+    logits: mx.array, top_p: float, temperature: float, axis: int = -1
+) -> mx.array:
     """
     Apply top-p (nucleus) sampling to logits.
 
@@ -72,29 +80,35 @@ def top_p_sampling(logits: mx.array, top_p: float, temperature: float) -> mx.arr
         logits: The logits from the model's output.
         top_p: The cumulative probability threshold for top-p filtering.
         temperature: Temperature parameter for softmax distribution reshaping.
+        axis: The axis along which to apply top-p sampling.
     Returns:
-        token selected based on the top-p criterion.
+        token(s) selected based on the top-p criterion.
     """
-    # referenced implementation from https://github.com/huggingface/transformers/blob/main/src/transformers/generation/logits_process.py#L449-L460
-    probs = mx.softmax(logits * (1 / temperature), axis=-1)
+    # Apply temperature and compute softmax
+    probs = mx.softmax(logits / temperature, axis=axis)
 
-    # sort probs in ascending order
-    sorted_indices = mx.argsort(probs, axis=-1)
-    sorted_probs = probs[..., sorted_indices.squeeze(0)]
+    # Sort probs in descending order
+    sorted_indices = mx.argsort(-probs, axis=axis)
+    sorted_probs = mx.take_along_axis(probs, sorted_indices, axis=axis)
 
-    cumulative_probs = mx.cumsum(sorted_probs, axis=-1)
+    # Compute cumulative probabilities
+    cumulative_probs = mx.cumsum(sorted_probs, axis=axis)
 
-    # select tokens with cumulative probs below threshold
-    top_probs = mx.where(
-        cumulative_probs > 1 - top_p,
-        sorted_probs,
-        0,
+    # Create a mask for probs above the threshold
+    mask = cumulative_probs <= top_p
+
+    # Apply the mask to the sorted probabilities
+    masked_probs = sorted_probs * mask
+
+    # Sample from the normalized probabilities
+    sampled_indices = mx.random.categorical(mx.log(masked_probs), axis=axis)
+
+    # Gather the original token indices
+    tokens = mx.take_along_axis(
+        sorted_indices, mx.expand_dims(sampled_indices, axis=axis), axis=axis
     )
 
-    sorted_token = mx.random.categorical(mx.log(top_probs))
-    token = sorted_indices.squeeze(0)[sorted_token]
-
-    return token
+    return tokens.squeeze(axis)
 
 
 @partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -104,6 +104,8 @@ class ModelProvider:
         # Preload the default model if it is provided
         if self.cli_args.model is not None:
             self.load("default_model")
+        if self.cli_args.draft_model is not None:
+            self.draft_model, _ = load(self.cli_args.model)
 
     def _validate_model_path(self, model_path: str):
         model_path = Path(model_path)
@@ -161,6 +163,7 @@ class APIHandler(BaseHTTPRequestHandler):
         """
         self.created = int(time.time())
         self.model_provider = model_provider
+        self.draft_model = model_provider.draft_model
         super().__init__(*args, **kwargs)
 
     def _set_cors_headers(self):
@@ -412,6 +415,8 @@ class APIHandler(BaseHTTPRequestHandler):
             generate_step(
                 prompts=prompt[None],
                 model=self.model,
+                draft_model=self.draft_model,
+                tokenizer=self.tokenizer,
                 temp=self.temperature,
                 top_p=self.top_p,
                 repetition_penalty=self.repetition_penalty,
@@ -501,6 +506,8 @@ class APIHandler(BaseHTTPRequestHandler):
             generate_step(
                 prompts=prompt[None],
                 model=self.model,
+                draft_model=self.draft_model,
+                tokenizer=self.tokenizer,
                 temp=self.temperature,
                 top_p=self.top_p,
                 repetition_penalty=self.repetition_penalty,
@@ -648,6 +655,11 @@ def main():
         "--model",
         type=str,
         help="The path to the MLX model weights, tokenizer, and config",
+    )
+    parser.add_argument(
+        "--draft-model",
+        type=str,
+        help="The path to the MLX model weights and config for speculative decoding",
     )
     parser.add_argument(
         "--adapter-path",

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -410,7 +410,7 @@ class APIHandler(BaseHTTPRequestHandler):
         top_tokens = []
         for (token, logprobs), _ in zip(
             generate_step(
-                prompt=prompt,
+                prompts=prompt[None],
                 model=self.model,
                 temp=self.temperature,
                 top_p=self.top_p,
@@ -420,6 +420,8 @@ class APIHandler(BaseHTTPRequestHandler):
             ),
             range(self.max_tokens),
         ):
+            token = token.item()
+            logprobs = logprobs.squeeze(0)
             detokenizer.add_token(token)
             logging.debug(detokenizer.text)
             tokens.append(token)
@@ -497,7 +499,7 @@ class APIHandler(BaseHTTPRequestHandler):
 
         for (token, _), _ in zip(
             generate_step(
-                prompt=prompt,
+                prompts=prompt[None],
                 model=self.model,
                 temp=self.temperature,
                 top_p=self.top_p,
@@ -506,6 +508,7 @@ class APIHandler(BaseHTTPRequestHandler):
             ),
             range(self.max_tokens),
         ):
+            token = token.item()
             detokenizer.add_token(token)
             logging.debug(detokenizer.text)
             tokens.append(token)

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -356,6 +356,8 @@ def generate(
             break
         if is_batch:
             output_toks.append(tokens)
+            if verbose:
+                print(".", end="", flush=True)
         else:
             token = tokens.item()
             logprobs = logprobs.squeeze(0)
@@ -385,6 +387,7 @@ def generate(
         if token_count <= 0:
             print("No tokens generated for this prompt")
         if is_batch:
+            print()
             for p, resp in zip(prompt, response):
                 print("=" * 10)
                 print("Prompt:", p)

--- a/llms/tests/test_models.py
+++ b/llms/tests/test_models.py
@@ -8,7 +8,6 @@ from mlx_lm.models.base import KVCache, RotatingKVCache
 
 
 class TestModels(unittest.TestCase):
-
     def test_kv_cache(self):
         cache = KVCache(32, 4)
 
@@ -28,6 +27,16 @@ class TestModels(unittest.TestCase):
         self.assertTrue(mx.array_equal(k_up, expected))
         self.assertTrue(mx.array_equal(v_up, expected))
         self.assertEqual(cache.offset, cache.step + 1)
+
+        cache.drop(5)
+        k = mx.ones((1, 4, 3, 32), mx.float16)
+        v = mx.ones((1, 4, 3, 32), mx.float16)
+        k_up, v_up = cache.update_and_fetch(k, v)
+
+        expected = mx.ones((1, 4, cache.step - 1, 32), mx.float16)
+        self.assertTrue(mx.array_equal(k_up, expected))
+        self.assertTrue(mx.array_equal(v_up, expected))
+        self.assertEqual(cache.offset, cache.step - 1)
 
     def test_rotating_kv_cache(self):
         b, h, d = 1, 2, 32
@@ -88,7 +97,6 @@ class TestModels(unittest.TestCase):
                 idx = 2
 
     def model_test_runner(self, model, model_type, vocab_size, num_layers):
-
         self.assertEqual(len(model.layers), num_layers)
         self.assertEqual(model.model_type, model_type)
 


### PR DESCRIPTION
Draft only because this is stacked on top of #948. Speculative decoding commit is https://github.com/ml-explore/mlx-examples/pull/954/commits/7d0e1cc4e0774a6d1e7092c3ed98454f7ed4f3ac

Implementation based on https://github.com/ml-explore/mlx-examples/pull/149. This basic version only supports bs=1, temp=0, max_kv_size=None. Supporting samplers, rotating cache, and batching are deferred to future commits in order to keep this diff small.

Note due to https://github.com/ml-explore/mlx-examples/pull/948#issuecomment-2309371987, the best speedup happens when the main model is unquantized.

Test (>2x speedup on my machine):
```sh
python -m llms.mlx_lm.generate --temp 0 --max-kv-size 0 \
  --model mlx-community/SmolLM-1.7B-Instruct-fp16 \
  --draft-model mlx-community/SmolLM-135M-Instruct-4bit \
  --prompt "Develop a Python program that reads all the text files under a directory and returns top-5 words with the most number of occurrences." \
  --max-tokens 500
```