### PR TITLE
feat(clip): add linear probe evaluation script

### DIFF
--- a/clip/eval.py
+++ b/clip/eval.py
@@ -1,0 +1,55 @@
+# Mirror of the Linear Probe Evaluation Script
+# from the official CLIP Repository.
+import mlx.core as mx
+import numpy as np
+from image_processor import CLIPImageProcessor
+from mlx.data.datasets import load_cifar10
+from model import CLIPModel
+from PIL import Image
+from sklearn.linear_model import LogisticRegression
+
+
+def get_cifar10(batch_size, root=None):
+    tr = load_cifar10(root=root)
+    tr_iter = tr.to_stream().batch(batch_size)
+
+    test = load_cifar10(root=root, train=False)
+    test_iter = test.to_stream().batch(batch_size)
+
+    return tr_iter, test_iter
+
+
+def get_features(model, image_proc, iter):
+    all_features = []
+    all_labels = []
+
+    for _, batch in enumerate(iter):
+        image, label = batch["image"], batch["label"]
+        x = image_proc([Image.fromarray(im) for im in image])
+        y = mx.array(label)
+
+        image_embeds = model.get_image_features(x)
+        all_features.append(image_embeds)
+        all_labels.append(y)
+
+    return mx.concatenate(all_features), mx.concatenate(all_labels)
+
+
+if __name__ == "__main__":
+    model = CLIPModel.from_pretrained("mlx_model")
+    image_proc = CLIPImageProcessor.from_pretrained("mlx_model")
+
+    train_iter, test_iter = get_cifar10(batch_size=256)
+    train_features, train_labels = get_features(model, image_proc, train_iter)
+    test_features, test_labels = get_features(model, image_proc, test_iter)
+
+    # Perform logistic regression
+    # NOTE: The value of C should be determined via a hyperparameter sweep
+    # using a validation split
+    classifier = LogisticRegression(random_state=0, C=0.316, max_iter=1000, verbose=1)
+    classifier.fit(train_features, train_labels)
+
+    # Evaluate using the logistic regression classifier
+    predictions = classifier.predict(test_features)
+    accuracy = np.mean((np.array(test_labels) == predictions).astype(float)) * 100.0
+    print(f"Accuracy = {accuracy:.3f}")

--- a/clip/linear_probe.py
+++ b/clip/linear_probe.py
@@ -1,5 +1,6 @@
 # Mirror of the Linear Probe Evaluation Script
 # from the official CLIP Repository.
+
 import mlx.core as mx
 import numpy as np
 from image_processor import CLIPImageProcessor
@@ -12,7 +13,6 @@ from tqdm import tqdm
 
 def get_cifar10(batch_size, root=None):
     tr = load_cifar10(root=root).batch(batch_size)
-
     test = load_cifar10(root=root, train=False).batch(batch_size)
 
     return tr, test
@@ -28,6 +28,8 @@ def get_features(model, image_proc, iter):
         y = mx.array(label)
 
         image_embeds = model.get_image_features(x)
+        mx.eval(image_embeds)
+
         all_features.append(image_embeds)
         all_labels.append(y)
 
@@ -50,5 +52,5 @@ if __name__ == "__main__":
 
     # Evaluate using the logistic regression classifier
     predictions = classifier.predict(test_features)
-    accuracy = np.mean((np.array(test_labels) == predictions).astype(float)) * 100.0
+    accuracy = (test_labels.squeeze() == predictions).mean().item() * 100
     print(f"Accuracy = {accuracy:.3f}")

--- a/clip/linear_probe.py
+++ b/clip/linear_probe.py
@@ -7,23 +7,22 @@ from mlx.data.datasets import load_cifar10
 from model import CLIPModel
 from PIL import Image
 from sklearn.linear_model import LogisticRegression
+from tqdm import tqdm
 
 
 def get_cifar10(batch_size, root=None):
-    tr = load_cifar10(root=root)
-    tr_iter = tr.to_stream().batch(batch_size)
+    tr = load_cifar10(root=root).batch(batch_size)
 
-    test = load_cifar10(root=root, train=False)
-    test_iter = test.to_stream().batch(batch_size)
+    test = load_cifar10(root=root, train=False).batch(batch_size)
 
-    return tr_iter, test_iter
+    return tr, test
 
 
 def get_features(model, image_proc, iter):
     all_features = []
     all_labels = []
 
-    for _, batch in enumerate(iter):
+    for batch in tqdm(iter):
         image, label = batch["image"], batch["label"]
         x = image_proc([Image.fromarray(im) for im in image])
         y = mx.array(label)

--- a/clip/requirements.txt
+++ b/clip/requirements.txt
@@ -1,4 +1,5 @@
 mlx
+mlx-data
 numpy
 transformers
 torch


### PR DESCRIPTION
Adds a script to perform linear probe evaluation using the `mlx.data` module for data loading. Mostly a mirror of the [Linear-probe evaluation script from the official CLIP repository](https://github.com/openai/CLIP?tab=readme-ov-file#linear-probe-evaluation).

## References

* https://github.com/ml-explore/mlx-examples/issues/959