### PR TITLE
Fix `setattr` for the TokenizerWrapper

### DIFF
--- a/llms/mlx_lm/tokenizer_utils.py
+++ b/llms/mlx_lm/tokenizer_utils.py
@@ -252,8 +252,18 @@ class TokenizerWrapper:
     def __getattr__(self, attr):
         if attr == "detokenizer":
             return self._detokenizer
+        elif attr.startswith("_"):
+            return self.__getattribute__(attr)
         else:
             return getattr(self._tokenizer, attr)
+
+    def __setattr__(self, attr, value):
+        if attr == "detokenizer":
+            raise AttributeError("Cannot set the detokenizer.")
+        elif attr.startswith("_"):
+            super().__setattr__(attr, value)
+        else:
+            setattr(self._tokenizer, attr, value)
 
 
 def _match(a, b):


### PR DESCRIPTION
Using the `--use-default-chat-template` seems to fail with the new `transformers` library and looking at how we handle `setattr` in the tokenizer wrapper seemed wrong anyway.

New behaviour: any `setattr` call is actually moved to the wrapped tokenizer except if it starts with an underscore.