### PR TITLE
Fix attention layers map  for SD-2-1-Base

### DIFF
--- a/stable_diffusion/stable_diffusion/model_io.py
+++ b/stable_diffusion/stable_diffusion/model_io.py
@@ -140,6 +140,17 @@ def map_vae_weights(key, value):
     if "to_v" in key:
         key = key.replace("to_v", "value_proj")
 
+
+    # Map attention layers in SD-2-1-base:VAE
+    if "key" in key:
+        key = key.replace("key", "to_k")
+    if "proj_attn" in key:
+        key = key.replace("proj_attn", "out_proj")
+    if "query" in key:
+        key = key.replace("query", "query_proj")
+    if "value" in key:
+        key = key.replace("value", "value_proj")
+
     # Map the mid block
     if "mid_block.resnets.0" in key:
         key = key.replace("mid_block.resnets.0", "mid_blocks.0")


### PR DESCRIPTION
The  [safetensors](https://huggingface.co/stabilityai/stable-diffusion-2-1-base/tree/main/vae?show_file_info=vae%2Fdiffusion_pytorch_model.safetensors) are not mapped correctly for attention layers of SD-2-1-base.