### PR TITLE
Update LLM generation docs to use chat template

### DIFF
--- a/llms/README.md
+++ b/llms/README.md
@@ -29,7 +29,14 @@ from mlx_lm import load, generate
 
 model, tokenizer = load("mlx-community/Mistral-7B-Instruct-v0.3-4bit")
 
-response = generate(model, tokenizer, prompt="hello", verbose=True)
+prompt = "Write a story about Einstein"
+
+messages = [{"role": "user", "content": prompt}]
+prompt = tokenizer.apply_chat_template(
+    messages, tokenize=False, add_generation_prompt=True
+)
+
+response = generate(model, tokenizer, prompt=prompt, verbose=True)
 ```
 
 To see a description of all the arguments you can do:
@@ -78,6 +85,11 @@ repo = "mlx-community/Mistral-7B-Instruct-v0.3-4bit"
 model, tokenizer = load(repo)
 
 prompt = "Write a story about Einstein"
+
+messages = [{"role": "user", "content": prompt}]
+prompt = tokenizer.apply_chat_template(
+    messages, tokenize=False, add_generation_prompt=True
+)
 
 for t in stream_generate(model, tokenizer, prompt, max_tokens=512):
     print(t, end="", flush=True)

--- a/llms/mlx_lm/_version.py
+++ b/llms/mlx_lm/_version.py
@@ -1,3 +1,3 @@
 # Copyright © 2023-2024 Apple Inc.
 
-__version__ = "0.18.1"
+__version__ = "0.18.2"

--- a/llms/mlx_lm/tokenizer_utils.py
+++ b/llms/mlx_lm/tokenizer_utils.py
@@ -265,6 +265,9 @@ class TokenizerWrapper:
         else:
             setattr(self._tokenizer, attr, value)
 
+    def __call__(self, *args, **kwargs):
+        return self._tokenizer(*args, **kwargs)
+
 
 def _match(a, b):
     if type(a) != type(b):

--- a/llms/mlx_lm/tokenizer_utils.py
+++ b/llms/mlx_lm/tokenizer_utils.py
@@ -265,9 +265,6 @@ class TokenizerWrapper:
         else:
             setattr(self._tokenizer, attr, value)
 
-    def __call__(self, *args, **kwargs):
-        return self._tokenizer(*args, **kwargs)
-
 
 def _match(a, b):
     if type(a) != type(b):

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -577,7 +577,16 @@ def upload_to_hub(path: str, upload_repo: str, hf_path: str):
         from mlx_lm import load, generate
 
         model, tokenizer = load("{upload_repo}")
-        response = generate(model, tokenizer, prompt="hello", verbose=True)
+
+        prompt="hello"
+
+        if hasattr(tokenizer, "apply_chat_template") and tokenizer.chat_template is not None:
+            messages = [{"role": "user", "content": prompt}]
+            prompt = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+
+        response = generate(model, tokenizer, prompt=prompt, verbose=True)
         ```
         """
     )


### PR DESCRIPTION
Since the docs use an instruct model, they should really use a chat template as well to be correct.

Also added a `__call__` overload to `TokenizerWrapper` to appease type-checking.

Closes #972 