### PR TITLE
Fix the cache_prompt

### DIFF
--- a/llms/mlx_lm/cache_prompt.py
+++ b/llms/mlx_lm/cache_prompt.py
@@ -139,8 +139,8 @@ def main():
     print("Saving...")
     cache_dict = {}
     for i, c in enumerate(cache):
-        cache_dict[f"{i}_keys"] = c.state[0]
-        cache_dict[f"{i}_values"] = c.state[1]
+        cache_dict[f"{i}_keys"] = c.state[0][..., : c.offset, :]
+        cache_dict[f"{i}_values"] = c.state[1][..., : c.offset, :]
     metadata = {}
     metadata["model"] = args.model
     metadata["chat_template"] = tokenizer.chat_template


### PR DESCRIPTION
This fixes #977 . The result is not going to be identical unfortunately due to the following tokenization artifact.

```python
tokenizer.encode("Hi!")             # [13347, 0]
tokenizer.encode("Hi! What's up?")  # [13347, 0, 3639, 596, 709, 30]
tokenizer.encode("What's up?")      # [3923, 596, 709, 30]
```