### PR TITLE
Add logits_processor option to generate_step function

### DIFF
--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -249,7 +249,7 @@ def generate_step(
         else:
             y, logprobs = sample(logits)
 
-        tokens_ids = mx.concat([tokens_ids, y], axis=0)
+        tokens = mx.concat([tokens, y], axis=0)
 
         if repetition_context_size:
             if len(repetition_context) > repetition_context_size:

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -183,7 +183,7 @@ def generate_step(
         max_kv_size (int, optional): Maximum size of the key-value cache. Old
           entries (except the first 4 tokens) will be overwritten.
         logits_processor (Callable[[mx.array, mx.array], mx.array], optional):
-            A function that takes tokens_ids and logits and returns the processed
+            A function that takes tokens and logits and returns the processed
             logits. Default: ``None``.
 
     Yields:
@@ -218,7 +218,7 @@ def generate_step(
         )
 
     y = prompt
-    tokens_ids = prompt
+    tokens = prompt
 
     # Create the KV cache for generation
     cache = make_kv_caches(model, max_kv_size)
@@ -239,12 +239,12 @@ def generate_step(
         repetition_context = repetition_context[-repetition_context_size:]
 
     def _step(y):
-        nonlocal repetition_context, tokens_ids
+        nonlocal repetition_context, tokens
         logits = model(y[None], cache=cache)
         logits = logits[:, -1, :]
 
         if logits_processor:
-            logits = logits_processor(tokens_ids, logits)
+            logits = logits_processor(tokens, logits)
 
         if repetition_penalty:
             logits = apply_repetition_penalty(

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -154,7 +154,6 @@ def generate_step(
     top_p: float = 1.0,
     min_p: float = 0.0,
     min_tokens_to_keep: int = 1,
-    logit_bias: Optional[Dict[int, float]] = None,
     prefill_step_size: int = 512,
     max_kv_size: Optional[int] = None,
     cache_history: Optional[List[Tuple[mx.array, mx.array]]] = None,
@@ -178,7 +177,6 @@ def generate_step(
           probability) that a token probability must have to be considered.
         min_tokens_to_keep (int, optional): Minimum number of tokens that cannot
           be filtered by min_p sampling.
-        logit_bias (dictionary, optional): Additive logit bias.
         prefill_step_size (int): Step size for processing the prompt.
         max_kv_size (int, optional): Maximum size of the key-value cache. Old
           entries (except the first 4 tokens) will be overwritten.
@@ -192,10 +190,6 @@ def generate_step(
     """
 
     def sample(logits: mx.array) -> Tuple[mx.array, float]:
-        if logit_bias:
-            indices = mx.array(list(logit_bias.keys()))
-            values = mx.array(list(logit_bias.values()))
-            logits[:, indices] += values
         logprobs = logits - mx.logsumexp(logits)
 
         if temp == 0:

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -255,7 +255,7 @@ def generate_step(
         else:
             y, logprobs = sample(logits)
 
-        tokens_ids = mx.concat(tokens_ids, y, dim=0)
+        tokens_ids = mx.concat([tokens_ids, y], axis=0)
 
         if repetition_context_size:
             if len(repetition_context) > repetition_context_size:

--- a/llms/tests/test_generate.py
+++ b/llms/tests/test_generate.py
@@ -1,0 +1,42 @@
+# Copyright © 2024 Apple Inc.
+
+import unittest
+
+from mlx_lm.utils import generate, load
+
+
+class TestGenerate(unittest.TestCase):
+
+    def test_generate(self):
+        # Simple test that generation runs
+        HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
+        model, tokenizer = load(HF_MODEL_PATH)
+        text = generate(model, tokenizer, "hello", max_tokens=5, verbose=False)
+
+    def test_generate_with_processor(self):
+        # Simple test that generation runs
+        HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
+        model, tokenizer = load(HF_MODEL_PATH)
+
+        init_toks = tokenizer.encode("hello")
+
+        all_toks = None
+
+        def logits_processor(toks, logits):
+            nonlocal all_toks
+            all_toks = toks
+            return logits
+
+        generate(
+            model,
+            tokenizer,
+            "hello",
+            max_tokens=5,
+            verbose=False,
+            logits_processor=logits_processor,
+        )
+        self.assertEqual(len(all_toks), len(init_toks) + 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/llms/tests/test_generate.py
+++ b/llms/tests/test_generate.py
@@ -7,18 +7,19 @@ from mlx_lm.utils import generate, load
 
 class TestGenerate(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
+        cls.model, cls.tokenizer = load(HF_MODEL_PATH)
+
     def test_generate(self):
         # Simple test that generation runs
-        HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
-        model, tokenizer = load(HF_MODEL_PATH)
-        text = generate(model, tokenizer, "hello", max_tokens=5, verbose=False)
+        text = generate(
+            self.model, self.tokenizer, "hello", max_tokens=5, verbose=False
+        )
 
     def test_generate_with_processor(self):
-        # Simple test that generation runs
-        HF_MODEL_PATH = "mlx-community/Qwen1.5-0.5B-Chat-4bit"
-        model, tokenizer = load(HF_MODEL_PATH)
-
-        init_toks = tokenizer.encode("hello")
+        init_toks = self.tokenizer.encode("hello")
 
         all_toks = None
 
@@ -28,8 +29,8 @@ class TestGenerate(unittest.TestCase):
             return logits
 
         generate(
-            model,
-            tokenizer,
+            self.model,
+            self.tokenizer,
             "hello",
             max_tokens=5,
             verbose=False,

--- a/llms/tests/test_generate.py
+++ b/llms/tests/test_generate.py
@@ -18,6 +18,18 @@ class TestGenerate(unittest.TestCase):
             self.model, self.tokenizer, "hello", max_tokens=5, verbose=False
         )
 
+    def test_generate_with_logit_bias(self):
+        logit_bias = {0: 2000.0, 1: -20.0}
+        text = generate(
+            self.model,
+            self.tokenizer,
+            "hello",
+            max_tokens=5,
+            verbose=False,
+            logit_bias=logit_bias,
+        )
+        self.assertEqual(text, "!!!!!")
+
     def test_generate_with_processor(self):
         init_toks = self.tokenizer.encode("hello")
 


### PR DESCRIPTION
This update introduces token masking capabilities to the `generate_step` function via a new `logits_processor` parameter. This enhancement supports constrained decoding scenarios that require token masking prior to sampling.

Updates include:
1. New `logits_processor` parameter in `generate_step` function
2. Token masking logic implemented within `_step` function
3. Updated docstring for `generate_step` to describe `logits_processor`
4. Created mx.array of all tokens including prompt

Usage example:
```python
def logits_processor(input_ids: mx.array, logits: mx.array) -> mx.array:
    return grammar_processor(input_ids, logits)
```
Here, `grammar_processor` could represent a custom constrained decoding approach.