### PR TITLE
Add /v1/models endpoint to mlx_lm.server

### DIFF
--- a/llms/mlx_lm/SERVER.md
+++ b/llms/mlx_lm/SERVER.md
@@ -85,3 +85,17 @@ curl localhost:8080/v1/chat/completions \
 
 - `adapters`: (Optional) A string path to low-rank adapters. The path must be
   rlative to the directory the server was started in.
+
+### List Models
+
+Use the `v1/models` endpoint to list available models:
+
+```shell
+curl localhost:8080/v1/models -H "Content-Type: application/json"
+```
+
+This will return a list of locally available models where each model in the
+list contains the following fields:
+
+- `"id"`: The Hugging Face repo id.
+- `"created"`: A timestamp representing the model creation time.

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Dict, List, Literal, NamedTuple, Optional, Sequence, Union
 
 import mlx.core as mx
+from huggingface_hub import scan_cache_dir
 
 from .utils import generate_step, load
 
@@ -635,13 +636,21 @@ class APIHandler(BaseHTTPRequestHandler):
         """
         self._set_completion_headers(200)
         self.end_headers()
+
+        # Scan the cache directory for downloaded mlx models
+        hf_cache_info = scan_cache_dir()
+        downloaded_models = [
+            repo for repo in hf_cache_info.repos if "mlx" in repo.repo_id
+        ]
+
         # Create a list of available models
         models = [
             {
-                "id": self.model_provider.cli_args.model,
+                "id": repo.repo_id,
                 "object": "model",
                 "created": self.created,
             }
+            for repo in downloaded_models
         ]
 
         response = {"object": "list", "data": models}

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -618,6 +618,38 @@ class APIHandler(BaseHTTPRequestHandler):
         prompt = self.tokenizer.encode(prompt_text)
         return mx.array(prompt)
 
+    def do_GET(self):
+        """
+        Respond to a GET request from a client.
+        """
+        if self.path == "/v1/models":
+            self.handle_models_request()
+        else:
+            self._set_completion_headers(404)
+            self.end_headers()
+            self.wfile.write(b"Not Found")
+
+    def handle_models_request(self):
+        """
+        Handle a GET request for the /v1/models endpoint.
+        """
+        self._set_completion_headers(200)
+        self.end_headers()
+        # Create a list of available models
+        models = [
+            {
+                "id": self.model_provider.cli_args.model,
+                "object": "model",
+                "created": self.created,
+            }
+        ]
+
+        response = {"object": "list", "data": models}
+
+        response_json = json.dumps(response).encode()
+        self.wfile.write(response_json)
+        self.wfile.flush()
+
 
 def run(
     host: str,

--- a/llms/tests/test_server.py
+++ b/llms/tests/test_server.py
@@ -6,7 +6,6 @@ import threading
 import unittest
 
 import requests
-from huggingface_hub import scan_cache_dir
 from mlx_lm.server import APIHandler
 from mlx_lm.utils import load
 
@@ -81,8 +80,6 @@ class TestServer(unittest.TestCase):
         self.assertIn("choices", response_body)
 
     def test_handle_models(self):
-        hf_cache_info = scan_cache_dir()
-        mlx_models = [repo for repo in hf_cache_info.repos if "mlx" in repo.repo_id]
         url = f"http://localhost:{self.port}/v1/models"
         response = requests.get(url)
         self.assertEqual(response.status_code, 200)
@@ -91,7 +88,7 @@ class TestServer(unittest.TestCase):
         self.assertIsInstance(response_body["data"], list)
         self.assertGreater(len(response_body["data"]), 0)
         model = response_body["data"][0]
-        self.assertEqual(model["id"], mlx_models[0].repo_id)
+        self.assertIn("id", model)
         self.assertEqual(model["object"], "model")
         self.assertIn("created", model)
 


### PR DESCRIPTION
This pull request introduces a new /v1/models endpoint to mlx_lm.server. The purpose of this addition is to improve compatibility with clients such as Open WebUI, which expect to retrieve a list of available models before use.

Changes:
1. Implemented GET request handling for the /v1/models route
2. Added a method to return information about the loaded model
3. Added tests for the /v1/models route

I've tested Open WebUI compatibility and this now works.
