### PR TITLE
LoRA: Support HuggingFace dataset via data parameter

### DIFF
--- a/llms/mlx_lm/tuner/datasets.py
+++ b/llms/mlx_lm/tuner/datasets.py
@@ -120,47 +120,52 @@ def load_hf_dataset(data_id: str, tokenizer: PreTrainedTokenizer):
     return train, valid, test
 
 
+def load_custom_hf_dataset(args, tokenizer: PreTrainedTokenizer):
+    import datasets
+
+    hf_args = args.hf_dataset
+    dataset_name = hf_args["name"]
+    print(f"Loading Hugging Face dataset {dataset_name}.")
+    text_feature = hf_args.get("text_feature")
+    prompt_feature = hf_args.get("prompt_feature")
+    completion_feature = hf_args.get("completion_feature")
+
+    def create_hf_dataset(split: str = None):
+        ds = datasets.load_dataset(
+            dataset_name,
+            split=split,
+            **hf_args.get("config", {}),
+        )
+        if prompt_feature and completion_feature:
+            return CompletionsDataset(
+                ds, tokenizer, prompt_feature, completion_feature
+            )
+        elif text_feature:
+            return Dataset(train_ds, text_key=text_feature)
+        else:
+            raise ValueError(
+                "Specify either a prompt and completion feature or a text "
+                "feature for the Hugging Face dataset."
+            )
+
+    if args.train:
+        train_split = hf_args.get("train_split", "train[:80%]")
+        valid_split = hf_args.get("valid_split", "train[-10%:]")
+        train = create_hf_dataset(split=train_split)
+        valid = create_hf_dataset(split=valid_split)
+    else:
+        train, valid = [], []
+    if args.test:
+        test = create_hf_dataset(split=hf_args.get("test_split"))
+    else:
+        test = []
+
+    return train, valid, test
+
+
 def load_dataset(args, tokenizer: PreTrainedTokenizer):
     if getattr(args, "hf_dataset", None) is not None:
-        import datasets
-
-        hf_args = args.hf_dataset
-        dataset_name = hf_args["name"]
-        print(f"Loading Hugging Face dataset {dataset_name}.")
-        text_feature = hf_args.get("text_feature")
-        prompt_feature = hf_args.get("prompt_feature")
-        completion_feature = hf_args.get("completion_feature")
-
-        def create_hf_dataset(split: str = None):
-            ds = datasets.load_dataset(
-                dataset_name,
-                split=split,
-                **hf_args.get("config", {}),
-            )
-            if prompt_feature and completion_feature:
-                return CompletionsDataset(
-                    ds, tokenizer, prompt_feature, completion_feature
-                )
-            elif text_feature:
-                return Dataset(train_ds, text_key=text_feature)
-            else:
-                raise ValueError(
-                    "Specify either a prompt and completion feature or a text "
-                    "feature for the Hugging Face dataset."
-                )
-
-        if args.train:
-            train_split = hf_args.get("train_split", "train[:80%]")
-            valid_split = hf_args.get("valid_split", "train[-10%:]")
-            train = create_hf_dataset(split=train_split)
-            valid = create_hf_dataset(split=valid_split)
-        else:
-            train, valid = [], []
-        if args.test:
-            test = create_hf_dataset(split=hf_args.get("test_split"))
-        else:
-            test = []
-
+        train, valid, test = load_custom_hf_dataset(args, tokenizer)
     else:
         data_path = Path(args.data)
         if data_path.exists():


### PR DESCRIPTION
I uploaded the example data from [lora/data](https://github.com/ml-explore/mlx-examples/tree/main/lora/data) to [mlx-community/wikisql](https://huggingface.co/datasets/mlx-community/wikisql) and specified the dataset id of HuggingFace via the `data` parameter.

Of course, the data field still supports local dataset paths, and will only use the HuggingFace dataset logic if the local path does not exist.


> [!note]
> The splitting rules for HuggingFace datasets are similar to the logic of local folders, requiring at least two data splits: `train` and `valid`.


The example is as follows:


```shell
mlx_lm.lora --model mlx-community/Qwen2.5-0.5B-Instruct-4bit \
               --data mlx-community/wikisql \
               --train \
               --learning-rate 1e-5 \
               --lora-layers 12 \
               --batch-size 10 \
               --max-seq-length 16384 \
               --iters 1000
```

logs

```
Loading pretrained model
Fetching 9 files: 100%|██████████████████████| 9/9 [00:00<00:00, 119837.26it/s]
Loading datasets
Downloading data: 100%|████████████████████████████████████| 74.0k/74.0k [00:00<00:00, 75.2kB/s]
Downloading data: 100%|████████████████████████████████████| 10.2k/10.2k [00:00<00:00, 17.8kB/s]
Downloading data: 100%|█████████████████████████████████████| 10.3k/10.3k [00:00<00:00, 12.9kB/s]
Generating train split: 100%|████████████████████████| 1000/1000 [00:00<00:00, 55431.82 examples/s]
Generating valid split: 100%|█████████████████████████| 100/100 [00:00<00:00, 109169.81 examples/s]
Generating test split: 100%|██████████████████████████| 100/100 [00:00<00:00, 136979.23 examples/s]
Training
Trainable parameters: 0.055% (0.270M/494.005M)
Starting training..., iters: 1000
Iter 1: Val loss 2.936, Val took 1.428s
```


