### PR TITLE
PR: Add KV-cache creation capability to mlx_lm.generate for after a text completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Then had to change generate.py to take --save-kv-cache as an argument which was 
 
 Messy, but seems to work!
 
-///
 
 # MLX Examples
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# This repo features changes to MLX_LM.
+Specfically main changes are from line 318 in utils.py; I kind of shoe-horned in the same kv-cache saving system as cache_prompt.py.
+
+Then had to change generate.py to take --save-kv-cache as an argument which was just a matter of changing the response handling on line 232 of generate.py.
+
+Messy, but seems to work!
+
+///
+
 # MLX Examples
 
 This repo contains a variety of standalone examples using the [MLX

--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
-# This repo features changes to MLX_LM.
-Specfically main changes are from line 318 in utils.py; I kind of shoe-horned in the same kv-cache saving system as cache_prompt.py.
-
-Then had to change generate.py to take --save-kv-cache as an argument which was just a matter of changing the response handling on line 232 of generate.py.
-
-Messy, but seems to work!
-
-
 # MLX Examples
 
 This repo contains a variety of standalone examples using the [MLX

--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -101,6 +101,12 @@ def setup_arg_parser():
         default=None,
         help="A file containing saved KV caches to avoid recomputing them",
     )
+    parser.add_argument(
+        "--save-kv-cache",
+        type=str,
+        default=None,
+        help="Path to save the final KV cache after generation",
+    )
     return parser
 
 
@@ -234,6 +240,7 @@ def main():
         top_p=args.top_p,
         max_kv_size=max_kv_size,
         cache_history=cache_history,
+        save_cache_path=args.save_kv_cache,  # Add this line
     )
     if not args.verbose:
         print(response)


### PR DESCRIPTION
Whilst mlx_lm.cache_prompt lets you encode a prompt and save the key value pairs as a kv-cache.safetensors file in advance, there's currently no means of saving the kv-cache after a text completion by an LLM.

Adding this will bring MLX_lm more in line with Llama.cpp in terms of reducing latency in multi-turn scenarios. For example, using an MLX-served model as a chatbot and having a drawn out discussion about a given topic. Saving the KV-cache after each turn by the LLM means that even as the conversation history continues, there won't be any latency introduced by having to re-encode the entire chat log again - only the most recent user prompt.

Not sure I went about it the best way, but it seems to work from my testing! There's one superfluous edit to the step generator line 357 which can probably be left out, but otherwise I think I kept this as streamlined as I could.