### PR TITLE
Fix rotating KV cache for chat use case

### DIFF
--- a/llms/mlx_lm/_version.py
+++ b/llms/mlx_lm/_version.py
@@ -1,3 +1,3 @@
 # Copyright © 2023-2024 Apple Inc.
 
-__version__ = "0.18.2"
+__version__ = "0.19.1"


### PR DESCRIPTION
The rotating KV cache didn't work if one alternates cache filling with generation. This fixes that + some tests.

Closes #1000 