### PR TITLE
Small typo fixed in flux README.md

### DIFF
--- a/flux/README.md
+++ b/flux/README.md
@@ -160,8 +160,8 @@ The adapters are saved in `mlx_output` and can be used directly by the
 `txt2image.py` script. For instance,
 
 ```shell
-python txt2img.py --model dev --save-raw --image-size 512x512 --n-images 1 \
-    --adapter mlx_output/mlx_output/0001200_adapters.safetensors \
+python txt2image.py --model dev --save-raw --image-size 512x512 --n-images 1 \
+    --adapter mlx_output/0001200_adapters.safetensors \
     --fuse-adapter \
     --no-t5-padding \
     'A photo of an sks dog lying on the sand at a beach in Greece'


### PR DESCRIPTION
Small typo fixed in flux README.md that txt2image.py