### PR TITLE
Fix PLaMo model to support Grouped Query Attention

### DIFF
--- a/llms/mlx_lm/models/plamo.py
+++ b/llms/mlx_lm/models/plamo.py
@@ -89,6 +89,9 @@ class Attention(nn.Module):
             queries = self.rotary_emb(queries)
             keys = self.rotary_emb(keys)
 
+        keys = mx.tile(keys, [1, self.config.n_shared_head, 1, 1])
+        values = mx.tile(values, [1, self.config.n_shared_head, 1, 1])
+
         output = mx.fast.scaled_dot_product_attention(
             queries,
             keys,


### PR DESCRIPTION
The model definition of PLaMo was updated in https://github.com/ml-explore/mlx-examples/pull/603 and it seems to have removed the shared key/value heads so that the output of PLaMo is broken for now.

This PR fixes the issue by reverting the removed part of shared kv heads (as like in llama models)