### PR TITLE
Make llm async eval less brittle

### DIFF
--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -246,10 +246,10 @@ def generate_step(
 
     y, logprobs = _step(y)
 
-    mx.async_eval(y)
+    mx.async_eval(y, logprobs)
     while True:
         next_y, next_logprobs = _step(y)
-        mx.async_eval(next_y)
+        mx.async_eval(next_y, next_logprobs)
         yield y.item(), logprobs
         y, logprobs = next_y, next_logprobs
 
@@ -348,7 +348,9 @@ def generate(
             if formatter:
                 # We have to finalize so that the prob corresponds to the last segment
                 detokenizer.finalize()
-                formatter(detokenizer.last_segment, mx.exp(logprobs[token]).item())
+                with mx.stream(mx.default_stream(mx.cpu)):
+                    prob = mx.exp(logprobs[token]).item()
+                formatter(detokenizer.last_segment, prob)
             else:
                 print(detokenizer.last_segment, end="", flush=True)
 


### PR DESCRIPTION
This is a partial fix for inadvertently slowing `async_eval` by putting in synchronization points:

- Everything that comes out of `generate_step` is already in the `async_eval`
- Everything outside of `generate_step` should be in a separate stream

After https://github.com/ml-explore/mlx/pull/1478 lands we should consider putting the whole async eval in it's own unique stream to avoid making this brittle to downstream code that processes `logprobs`.