### PR TITLE
Add option to wire model

### DIFF
--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -111,8 +111,10 @@ def setup_arg_parser():
         "--wire-model",
         "-w",
         action="store_true",
-        help=("Keep the model resident in memory. This can substantially "
-         "speedup generation for models large relative to the machine's RAM.")
+        help=(
+            "Keep the model resident in memory. This can substantially "
+            "speedup generation for models large relative to the machine's RAM."
+        ),
     )
 
     return parser
@@ -230,7 +232,8 @@ def main():
             raise ValueError(
                 "Cannot wire a model larger than the available RAM. You may "
                 "be able to increase the available RAM by setting "
-                "`sudo sysctl iogpu.wired_limit_mb=N` to a larger value")
+                "`sudo sysctl iogpu.wired_limit_mb=N` to a larger value"
+            )
 
     response = generate(
         model,


### PR DESCRIPTION
Wires the model if requested.

With `-w` set on an M2 Ultra (nothing else needed) the #s for Llama 3.1 70B in 16-bit precision look like:

 | | not wired | wired
---  | --- | ---
prompt (16 toks)  | 2.35 toks/sec |  27.8 toks/sec
generation (100 toks) | 0.23 toks/sec | 4.7 toks/sec


Command ran:

```bash
python -m mlx_lm.generate --model meta-llama/Meta-Llama-3-70B-Instruct --prompt "Write a story about Einstein" --max-tokens 100
```

Requires https://github.com/ml-explore/mlx/pull/1510