### PR TITLE
Update lora_config.yaml with new param: num_layers

### DIFF
--- a/llms/mlx_lm/examples/lora_config.yaml
+++ b/llms/mlx_lm/examples/lora_config.yaml
@@ -14,7 +14,7 @@ data: "/path/to/training/data"
 seed: 0
 
 # Number of layers to fine-tune
-lora_layers: 16
+num_layers: 16
 
 # Minibatch size.
 batch_size: 4


### PR DESCRIPTION
Fix for #1067:
When updating the config yaml for the addition of full parameter tuning, the `lora_layers` parameter was not adjusted to the new param `num_layers`. In this PR the example lora_config.yaml will be updated with the new param.