### PR TITLE
Fix detokenizer space match for quote

### DIFF
--- a/llms/mlx_lm/__init__.py
+++ b/llms/mlx_lm/__init__.py
@@ -1,4 +1,10 @@
 # Copyright © 2023-2024 Apple Inc.
 
 from ._version import __version__
+
+import os
+os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
+
 from .utils import convert, generate, load, stream_generate
+
+

--- a/llms/mlx_lm/__init__.py
+++ b/llms/mlx_lm/__init__.py
@@ -1,10 +1,9 @@
 # Copyright © 2023-2024 Apple Inc.
 
+import os
+
 from ._version import __version__
 
-import os
 os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
 
 from .utils import convert, generate, load, stream_generate
-
-

--- a/llms/mlx_lm/tokenizer_utils.py
+++ b/llms/mlx_lm/tokenizer_utils.py
@@ -169,7 +169,7 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
     """
 
     _byte_decoder = None
-    _space_matches = (".", "?", "!", ",", "'", "n't", "'m", "'s", "'ve", "'re")
+    _space_matches = (".", "?", "!", ",", "n't", "'m", "'s", "'ve", "'re")
 
     def __init__(self, tokenizer):
 

--- a/llms/tests/test_tokenizers.py
+++ b/llms/tests/test_tokenizers.py
@@ -51,6 +51,9 @@ class TestTokenizers(unittest.TestCase):
         tokens = tokenizer.encode("3 3")
         check(tokens)
 
+        tokens = tokenizer.encode("import 'package:flutter/material.dart';")
+        check(tokens)
+
     def test_tokenizers(self):
         tokenizer_repos = [
             ("mlx-community/Qwen1.5-0.5B-Chat-4bit", BPEStreamingDetokenizer),


### PR DESCRIPTION
I introduces a bug when trying to port the `clean_up_tokenization_spaces` from HF.

Their match is actually to find and replace instances of ` ' ` with `'`. That one specifically requires a special case to post-process which is tedious, so I just removed that case as I have never seen it come up. But if it does we can revisit.

For reference, the [transformers matching conditions](https://github.com/huggingface/transformers/blob/main/src/transformers/tokenization_utils_base.py#L4052).

Closes #1073 