### PR TITLE
Add Max Token Limit for Generation

### DIFF
--- a/llms/mlx_lm/chat.py
+++ b/llms/mlx_lm/chat.py
@@ -29,7 +29,16 @@ def setup_arg_parser():
         help="Optional path for the trained adapter weights and config.",
     )
     parser.add_argument(
-        "--temp", type=float, default=DEFAULT_TEMP, help="Sampling temperature"
+        "--max-tokens-per-sec",
+        type=int,
+        help="Maximum tokens to generate per second.",
+        default=None,
+    )
+    parser.add_argument(
+        "--max-tokens-per-sec",
+        type=int,
+        default=None,
+        help="Maximum tokens to generate per second",
     )
     parser.add_argument(
         "--top-p", type=float, default=DEFAULT_TOP_P, help="Sampling top-p"
@@ -56,7 +65,7 @@ def main():
         tokenizer_config={"trust_remote_code": True},
     )
 
-    print(f"[INFO] Starting chat sessiong with {args.model}. To exit, enter 'q'.")
+    print(f"[INFO] Starting chat session with {args.model}. To exit, enter 'q'.")
     prompt_cache = make_prompt_cache(model, args.max_kv_size)
     while True:
         query = input(">> ")
@@ -72,7 +81,9 @@ def main():
             prompt,
             temp=args.temp,
             top_p=args.top_p,
+            max_tokens_per_sec=args.max_tokens_per_sec,
             prompt_cache=prompt_cache,
+            max_tokens=4096 # Ensure this is set to a reasonable limit
         ):
             print(response, flush=True, end="")
         print()

--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -9,8 +9,8 @@ import mlx.core as mx
 from .models.cache import load_prompt_cache
 from .utils import generate, load
 
-DEFAULT_PROMPT = "hello"
-DEFAULT_MAX_TOKENS = 100
+DEFAULT_PROMPT = "Tell me a story!"
+DEFAULT_MAX_TOKENS = 1000
 DEFAULT_TEMP = 0.0
 DEFAULT_TOP_P = 1.0
 DEFAULT_SEED = 0
@@ -60,6 +60,12 @@ def setup_arg_parser():
         type=int,
         default=DEFAULT_MAX_TOKENS,
         help="Maximum number of tokens to generate",
+    )
+    parser.add_argument(
+        "--max-tokens-per-sec",
+        type=int,
+        default=None,
+        help="Maximum tokens to generate per second",
     )
     parser.add_argument(
         "--temp", type=float, default=DEFAULT_TEMP, help="Sampling temperature"
@@ -227,6 +233,7 @@ def main():
         top_p=args.top_p,
         max_kv_size=args.max_kv_size,
         prompt_cache=prompt_cache if using_cache else None,
+        max_tokens_per_sec=args.max_tokens_per_sec,
     )
     if not args.verbose:
         print(response)

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -146,7 +146,7 @@ def generate_step(
         prompt (mx.array): The input prompt.
         model (nn.Module): The model to use for generation.
         temp (float): The temperature for sampling, if 0 the argmax is used. Default: ``0``.
-      repetition_penalty (float, optional): The penalty factor for repeating
+        repetition_penalty (float, optional): The penalty factor for repeating
           tokens.
         repetition_context_size (int, optional): The number of tokens to
           consider for repetition penalty. Default: ``20``.
@@ -277,38 +277,18 @@ def stream_generate(
     **kwargs,
 ) -> Union[str, Generator[str, None, None]]:
     """
-    A generator producing token ids based on the given prompt from the model.
+    A generator producing text based on the given prompt from the model.
 
     Args:
         prompt (mx.array): The input prompt.
         model (nn.Module): The model to use for generation.
-        temp (float): The temperature for sampling, if 0 the argmax is used.
-          Default: ``0``.
-        repetition_penalty (float, optional): The penalty factor for repeating
-          tokens.
-        repetition_context_size (int, optional): The number of tokens to
-          consider for repetition penalty. Default: ``20``.
-        top_p (float, optional): Nulceus sampling, higher means model considers
-          more less likely words.
-        min_p (float, optional): The minimum value (scaled by the top token's
-          probability) that a token probability must have to be considered.
-        min_tokens_to_keep (int, optional): Minimum number of tokens that cannot
-          be filtered by min_p sampling.
-        prefill_step_size (int): Step size for processing the prompt.
-        max_kv_size (int, optional): Maximum size of the key-value cache. Old
-          entries (except the first 4 tokens) will be overwritten.
-        prompt_cache (List[Any], optional): A pre-computed prompt cache. Note, if
-          provided, the cache will be updated in place.
-        logit_bias (dictionary, optional): Additive logit bias.
-        logits_processor (List[Callable[[mx.array, mx.array], mx.array]], optional):
-            A list of functions that take tokens and logits and return the processed
-            logits. Default: ``None``.
-        max_tokens_per_sec (float, optional): If set, limits generation speed to approximately 
-            this many tokens per second by adding delays between tokens. Useful for thermal/power
-            management. Default: None (no limit).
+        max_tokens (int): The maximum number of tokens. Default: ``100``.
+        max_tokens_per_sec (float, optional): If set, limits generation speed to approximately max_tokens_per_sec. May go slightly over this limit.
+        kwargs: The remaining options get passed to :func:`generate_step`.
+          See :func:`generate_step` for more details.
+
     Yields:
-        Generator[Tuple[mx.array, mx.array], None, None]: A generator producing
-          one token and a vector of log probabilities.
+        Generator[Tuple[mx.array, mx.array]]: A generator producing text.
     """
 
     if not isinstance(tokenizer, TokenizerWrapper):


### PR DESCRIPTION
Allows the throttling of the generation process to a maximum number of tok/sec - meaning that the user can control what percent of their GPU power goes into LLM generation. Avoids thermal throttling.