### PR TITLE
Clear cache every now and then

### DIFF
--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -91,12 +91,6 @@ def setup_arg_parser():
         help="Colorize output based on T[0] probability",
     )
     parser.add_argument(
-        "--cache-limit-gb",
-        type=int,
-        default=None,
-        help="Set the MLX cache limit in GB",
-    )
-    parser.add_argument(
         "--max-kv-size",
         type=int,
         help="Set the maximum key-value cache size",
@@ -163,9 +157,6 @@ def main():
     args = parser.parse_args()
 
     mx.random.seed(args.seed)
-
-    if args.cache_limit_gb is not None:
-        mx.metal.set_cache_limit(args.cache_limit_gb * 1024 * 1024 * 1024)
 
     # Load the prompt cache and metadata if a cache file is provided
     using_cache = args.prompt_cache_file is not None

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -310,10 +310,14 @@ def generate_step(
     y, logprobs = _step(y)
 
     mx.async_eval(y, logprobs)
+    n = 0
     while True:
         next_y, next_logprobs = _step(y)
         mx.async_eval(next_y, next_logprobs)
         yield y.item(), logprobs
+        if n % 256 == 0:
+            mx.metal.clear_cache()
+        n += 1
         y, logprobs = next_y, next_logprobs
 
 


### PR DESCRIPTION
As we step the KV cache.. the buffer cache fills up which causes the machine to use more RAM than is really needed.

For example:

```
mlx_lm.generate --model mlx-community/Meta-Llama-3.1-8B-Instruct-4bit -m 2048 --prompt - < prompt.txt
```

Pre:
```
Prompt: 32188 tokens, 430.339 tokens-per-sec
Generation: 892 tokens, 32.480 tokens-per-sec
Peak memory: 11.496 GB
Cache memory: 22.795 GB
```

Post:

```
Prompt: 32188 tokens, 424.646 tokens-per-sec
Generation: 892 tokens, 32.211 tokens-per-sec
Peak memory: 11.496 GB
Cache memory: 4.034 GB
```

No difference on M2 Ultra with:

```
mlx_lm.generate --model mlx-community/Mistral-7B-Instruct-v0.3-4bit --prompt "Write a story about Einstein"  --temp 0.0 --max-tokens 512
```

Still hits about 120.5 toks/sec