### PR TITLE
Fix rotating kv cache size

### DIFF
--- a/llms/mlx_lm/models/base.py
+++ b/llms/mlx_lm/models/base.py
@@ -42,7 +42,7 @@ def create_attention_mask(h: mx.array, cache: Optional[Any] = None):
         if cache is not None and cache[0] is not None:
             c = cache[0]
             if hasattr(c, "max_size"):
-                offset = min(c.max_size - 1, c.offset)
+                offset = min(c.max_size, c.offset)
                 window_size = c.max_size
             else:
                 offset = c.offset

--- a/llms/mlx_lm/models/cache.py
+++ b/llms/mlx_lm/models/cache.py
@@ -325,9 +325,9 @@ class RotatingKVCache(_BaseCache):
             self.keys = self._temporal_order(self.keys)
             self.values = self._temporal_order(self.values)
 
-            # The largest size is self.max_size + S - 1 to ensure
+            # The largest size is self.max_size + S to ensure
             # every token gets at least self.max_size context
-            trim_size = self._idx - self.max_size + 1
+            trim_size = self._idx - self.max_size
             self.keys = self._trim(trim_size, self.keys, keys)
             self.values = self._trim(trim_size, self.values, values)
         self.offset += keys.shape[2]


### PR DESCRIPTION
Currently the rotating KV cache can be both `max_size` and `max_size - 1` depending on whether we filled it by generating or by prompt token processing. This PR makes sure the max is always `max_size ` and not `max_size - 1`.

The following two simple repros exemplify the problem a bit:

### Generate past max size
```python
from mlx_lm.models.cache import make_prompt_cache
from mlx_lm.utils import load
from mlx_lm.utils import stream_generate

PROMPT = "Tell me a story"

model, tokenizer = load("mlx-community/Llama-3.2-3B-Instruct-4bit")

cache = make_prompt_cache(model, max_kv_size=100)
for text in stream_generate(model, tokenizer, PROMPT, prompt_cache=cache, max_tokens=100):
    pass
for text in stream_generate(model, tokenizer, PROMPT, prompt_cache=cache, max_tokens=100):
    pass
```

### Prompt process past max size
```python
from mlx_lm.models.cache import make_prompt_cache
from mlx_lm.utils import load
from mlx_lm.utils import stream_generate

PROMPT = "Tell me a story "

model, tokenizer = load("mlx-community/Llama-3.2-3B-Instruct-4bit")

cache = make_prompt_cache(model, max_kv_size=512)
for text in stream_generate(model, tokenizer, PROMPT * 384, prompt_cache=cache, max_tokens=50):
    pass
```

The first breaks on main. Then changing line 45 on base.py breaks the 2nd test and changing the trim size makes sure everything works. Btw these also occur in `mlx_lm.chat` and `mlx_lm.cache_prompt` it is just more explicit with the tests above.