### PR TITLE
Fix data_iter in prepare_dataset from speechcommands example

### DIFF
--- a/speechcommands/main.py
+++ b/speechcommands/main.py
@@ -48,7 +48,6 @@ def prepare_dataset(batch_size, split, root=None):
         .batch(batch_size)
         .to_stream()
         .prefetch(4, 4)
-        .to_buffer()
     )
     return data_iter
 
@@ -77,6 +76,7 @@ def train_epoch(model, train_iter, optimizer, epoch):
     samples_per_sec = []
 
     model.train(True)
+    train_iter.reset()
     for batch_counter, batch in enumerate(train_iter):
         x = mx.array(batch["audio"])
         y = mx.array(batch["label"])
@@ -112,6 +112,7 @@ def test_epoch(model, test_iter):
     model.train(False)
     accs = []
     throughput = []
+    test_iter.reset()
     for batch_counter, batch in enumerate(test_iter):
         x = mx.array(batch["audio"])
         y = mx.array(batch["label"])

--- a/speechcommands/main.py
+++ b/speechcommands/main.py
@@ -48,6 +48,7 @@ def prepare_dataset(batch_size, split, root=None):
         .batch(batch_size)
         .to_stream()
         .prefetch(4, 4)
+        .to_buffer()
     )
     return data_iter
 


### PR DESCRIPTION
Current speechcommands [example](https://github.com/ml-explore/mlx-examples/tree/main/speechcommands#running-the-example) have `nan` value for training loss when iterating from epoch 1 . Looks like there were missing `to_buffer()` sequence in the `data_iter`.

So, we manage to add `to_buffer()` regarding librispeech [config](https://github.com/ml-explore/mlx-data/blob/main/python/mlx/data/datasets/librispeech.py#L134) since we haven't see the actual `to_buffer()` in the `load_speechcommands` [function](https://github.com/ml-explore/mlx-data/blob/main/python/mlx/data/datasets/speechcommands.py#L117-L121)

### version
```bash
(base) ➜  ~ python --version
Python 3.12.4
(base) ➜  ~ python -c "import mlx.core as mx; print(mx.__version__)"
0.20.0
```

### Before
```bash
(base) ➜  speechcommands git:(main) ✗ python main.py --epochs=3
Number of params: 0.6089 M
Epoch 00 [000] | Train loss 3.651 | Train acc 0.027 | Throughput: 1191.21 samples/second
Epoch 00 [025] | Train loss 3.440 | Train acc 0.059 | Throughput: 3768.70 samples/second
Epoch 00 [050] | Train loss 3.434 | Train acc 0.109 | Throughput: 3785.60 samples/second
Epoch 00 [075] | Train loss 3.293 | Train acc 0.148 | Throughput: 3777.03 samples/second
Epoch 00 [100] | Train loss 3.157 | Train acc 0.152 | Throughput: 3814.83 samples/second
Epoch 00 [125] | Train loss 3.130 | Train acc 0.125 | Throughput: 3830.12 samples/second
Epoch 00 [150] | Train loss 2.972 | Train acc 0.195 | Throughput: 3818.13 samples/second
Epoch 00 [175] | Train loss 2.942 | Train acc 0.215 | Throughput: 3812.41 samples/second
Epoch 00 [200] | Train loss 2.632 | Train acc 0.289 | Throughput: 3791.92 samples/second
Epoch 00 [225] | Train loss 2.591 | Train acc 0.305 | Throughput: 3848.51 samples/second
Epoch 00 [250] | Train loss 2.495 | Train acc 0.328 | Throughput: 3876.88 samples/second
Epoch 00 [275] | Train loss 2.441 | Train acc 0.340 | Throughput: 3885.04 samples/second
Epoch 00 [300] | Train loss 2.202 | Train acc 0.480 | Throughput: 3896.76 samples/second
Epoch 00 [325] | Train loss 2.079 | Train acc 0.520 | Throughput: 3903.71 samples/second
Epoch: 0 | avg. Train loss 2.873 | avg. Train acc 0.236 | Throughput: 3800.89 samples/sec
Epoch: 0 | Val acc 0.499 | Throughput: 15228.54 samples/sec
Epoch: 1 | avg. Train loss nan | avg. Train acc nan | Throughput: nan samples/sec
Epoch: 1 | Val acc nan | Throughput: nan samples/sec
Epoch: 2 | avg. Train loss nan | avg. Train acc nan | Throughput: nan samples/sec
Epoch: 2 | Val acc nan | Throughput: nan samples/sec
Testing best model from epoch 0
Test acc -> 0.490
```

### After
```bash
(base) ➜  speechcommands git:(fix_speechcommands_prepare_dataset) python main.py --epochs=3                         
Number of params: 0.6089 M
Epoch 00 [000] | Train loss 3.689 | Train acc 0.051 | Throughput: 2083.56 samples/second
Epoch 00 [025] | Train loss 3.476 | Train acc 0.055 | Throughput: 3878.16 samples/second
Epoch 00 [050] | Train loss 3.373 | Train acc 0.102 | Throughput: 3926.96 samples/second
Epoch 00 [075] | Train loss 3.221 | Train acc 0.113 | Throughput: 3929.35 samples/second
Epoch 00 [100] | Train loss 3.160 | Train acc 0.172 | Throughput: 3925.73 samples/second
Epoch 00 [125] | Train loss 3.063 | Train acc 0.180 | Throughput: 3923.14 samples/second
Epoch 00 [150] | Train loss 2.959 | Train acc 0.188 | Throughput: 3733.52 samples/second
Epoch 00 [175] | Train loss 2.817 | Train acc 0.203 | Throughput: 3915.15 samples/second
Epoch 00 [200] | Train loss 2.764 | Train acc 0.234 | Throughput: 3921.87 samples/second
Epoch 00 [225] | Train loss 2.615 | Train acc 0.273 | Throughput: 3922.52 samples/second
Epoch 00 [250] | Train loss 2.518 | Train acc 0.332 | Throughput: 3927.06 samples/second
Epoch 00 [275] | Train loss 2.362 | Train acc 0.406 | Throughput: 3912.77 samples/second
Epoch 00 [300] | Train loss 2.267 | Train acc 0.457 | Throughput: 3930.39 samples/second
Epoch 00 [325] | Train loss 2.128 | Train acc 0.449 | Throughput: 3927.78 samples/second
Epoch: 0 | avg. Train loss 2.879 | avg. Train acc 0.237 | Throughput: 3905.11 samples/sec
Epoch: 0 | Val acc 0.479 | Throughput: 18634.02 samples/sec
Epoch 01 [000] | Train loss 2.098 | Train acc 0.480 | Throughput: 3646.66 samples/second
Epoch 01 [025] | Train loss 2.000 | Train acc 0.496 | Throughput: 3970.95 samples/second
Epoch 01 [050] | Train loss 1.951 | Train acc 0.516 | Throughput: 3998.85 samples/second
Epoch 01 [075] | Train loss 1.732 | Train acc 0.609 | Throughput: 3980.80 samples/second
Epoch 01 [100] | Train loss 1.809 | Train acc 0.582 | Throughput: 3961.70 samples/second
Epoch 01 [125] | Train loss 1.682 | Train acc 0.586 | Throughput: 3992.19 samples/second
Epoch 01 [150] | Train loss 1.644 | Train acc 0.547 | Throughput: 3970.20 samples/second
Epoch 01 [175] | Train loss 1.521 | Train acc 0.660 | Throughput: 3949.02 samples/second
Epoch 01 [200] | Train loss 1.665 | Train acc 0.613 | Throughput: 3974.02 samples/second
Epoch 01 [225] | Train loss 1.612 | Train acc 0.570 | Throughput: 3967.83 samples/second
Epoch 01 [250] | Train loss 1.453 | Train acc 0.648 | Throughput: 3982.09 samples/second
Epoch 01 [275] | Train loss 1.395 | Train acc 0.656 | Throughput: 3962.64 samples/second
Epoch 01 [300] | Train loss 1.363 | Train acc 0.652 | Throughput: 3966.09 samples/second
Epoch 01 [325] | Train loss 1.213 | Train acc 0.711 | Throughput: 3984.85 samples/second
Epoch: 1 | avg. Train loss 1.654 | avg. Train acc 0.593 | Throughput: 3966.92 samples/sec
Epoch: 1 | Val acc 0.692 | Throughput: 18587.79 samples/sec
Epoch 02 [000] | Train loss 1.279 | Train acc 0.684 | Throughput: 3652.29 samples/second
Epoch 02 [025] | Train loss 1.275 | Train acc 0.691 | Throughput: 3990.19 samples/second
Epoch 02 [050] | Train loss 1.272 | Train acc 0.672 | Throughput: 4006.45 samples/second
Epoch 02 [075] | Train loss 1.139 | Train acc 0.727 | Throughput: 3993.12 samples/second
Epoch 02 [100] | Train loss 1.236 | Train acc 0.684 | Throughput: 4011.32 samples/second
Epoch 02 [125] | Train loss 1.153 | Train acc 0.707 | Throughput: 3976.58 samples/second
Epoch 02 [150] | Train loss 1.138 | Train acc 0.688 | Throughput: 3962.98 samples/second
Epoch 02 [175] | Train loss 1.055 | Train acc 0.773 | Throughput: 4010.72 samples/second
Epoch 02 [200] | Train loss 1.176 | Train acc 0.711 | Throughput: 3955.77 samples/second
Epoch 02 [225] | Train loss 1.163 | Train acc 0.699 | Throughput: 3595.65 samples/second
Epoch 02 [250] | Train loss 1.068 | Train acc 0.734 | Throughput: 3975.70 samples/second
Epoch 02 [275] | Train loss 1.045 | Train acc 0.719 | Throughput: 3916.76 samples/second
Epoch 02 [300] | Train loss 1.029 | Train acc 0.727 | Throughput: 3989.62 samples/second
Epoch 02 [325] | Train loss 0.895 | Train acc 0.766 | Throughput: 3891.52 samples/second
Epoch: 2 | avg. Train loss 1.138 | avg. Train acc 0.717 | Throughput: 3962.98 samples/sec
Epoch: 2 | Val acc 0.766 | Throughput: 18683.26 samples/sec
Testing best model from epoch 2
Test acc -> 0.755
```