### PR TITLE
Allow loading from diffusers ckpt

### DIFF
--- a/flux/flux/model.py
+++ b/flux/flux/model.py
@@ -85,6 +85,8 @@ class Flux(nn.Module):
     def sanitize(self, weights):
         new_weights = {}
         for k, w in weights.items():
+            if k.startswith("model.diffusion_model."):
+                k = k[22:]
             if k.endswith(".scale"):
                 k = k[:-6] + ".weight"
             for seq in ["img_mlp", "txt_mlp", "adaLN_modulation"]:


### PR DESCRIPTION
Fixes #1116 .

The original checkpoint saved just the transformer model but in the diffusers checkpoint the transformer is nested in the `model` and `diffusion_model`. It seems that the transformer folder would be loadable as is but this small addition to `sanitize()` will work just as well.