### PR TITLE
Fix: Allow converting whisper models from local paths

### DIFF
--- a/whisper/convert.py
+++ b/whisper/convert.py
@@ -174,11 +174,6 @@ def load_torch_weights_and_config(
                 "*.txt",
             ],
         )
-    else:
-        raise RuntimeError(
-            f"Model {name_or_path} is not found in {available_models()},"
-            "on Hugging Face or as a local path."
-        )
 
     if name_or_path.endswith(".pt"):
         checkpoint = torch.load(name_or_path, map_location="cpu", weights_only=False)


### PR DESCRIPTION
For some reason current implementation logic in the conversion script only allows to use models from predefined list or from huggingface, but when an existing path to a model on a local drive is specified in `--torch-name-or-path` argument, it throws an error.  This error is misleading since it is thrown when a local path actually exists.