### PR TITLE
Fix object property value in mlx_lm.server chat completions response not matching OpenAI spec

### DIFF
--- a/llms/mlx_lm/SERVER.md
+++ b/llms/mlx_lm/SERVER.md
@@ -92,7 +92,7 @@ curl localhost:8080/v1/chat/completions \
 
 - `system_fingerprint`: A unique identifier for the system.
 
-- `object`: Any of "chat.completions", "chat.completions.chunk" (for
+- `object`: Any of "chat.completion", "chat.completion.chunk" (for
   streaming), or "text.completion".
 
 - `model`: The model repo or path (e.g. `"mlx-community/Llama-3.2-3B-Instruct-4bit"`).

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -589,9 +589,7 @@ class APIHandler(BaseHTTPRequestHandler):
 
         # Determine response type
         self.request_id = f"chatcmpl-{uuid.uuid4()}"
-        self.object_type = (
-            "chat.completions.chunk" if self.stream else "chat.completions"
-        )
+        self.object_type = "chat.completion.chunk" if self.stream else "chat.completion"
         if (
             hasattr(self.tokenizer, "apply_chat_template")
             and self.tokenizer.chat_template


### PR DESCRIPTION
In `mlx_lm.server`'s POST /chat/completions, the "object" property did not match OpenAI's spec.

The value produced was "chat.completions" or "chat.completions.chunk", but should be "chat.completion" or "chat.completion.chunk" for compatibility with clients expecting an OpenAI API.

Refer to:

[The chat completion object](https://platform.openai.com/docs/api-reference/chat/object)

> object string
> The object type, which is always chat.completion.

[The chat completion chunk object](https://platform.openai.com/docs/api-reference/chat/streaming)

> object string
> The object type, which is always chat.completion.chunk.

In particular, this solves a problem for me in which aider 0.64.1 reports hitting a token limit on any chat completion request to mlx_lm.server, no matter how small, despite apparently correct counts in the usage property.