### PR TITLE
Mixed Quantizations

### DIFF
--- a/llms/mlx_lm/tuner/utils.py
+++ b/llms/mlx_lm/tuner/utils.py
@@ -250,8 +250,9 @@ def remove_lora_layers(model: nn.Module) -> nn.Module:
 
 
 def nparams(module):
-    if isinstance(module, (nn.QuantizedLinear, nn.QuantizedEmbedding)):
-        return module.weight.size * 32 // module.bits
+    if hasattr(module, "bits"):
+        n = 0 if not hasattr(module, "bias") else module.bias.size
+        return n + module.weight.size * 32 // module.bits
     return sum(v.size for _, v in tree_flatten(module.parameters()))
 
 

--- a/llms/mlx_lm/tuner/utils.py
+++ b/llms/mlx_lm/tuner/utils.py
@@ -249,12 +249,13 @@ def remove_lora_layers(model: nn.Module) -> nn.Module:
     return model
 
 
-def print_trainable_parameters(model):
-    def nparams(m):
-        if isinstance(m, (nn.QuantizedLinear, nn.QuantizedEmbedding)):
-            return m.weight.size * (32 // m.bits)
-        return sum(v.size for _, v in tree_flatten(m.parameters()))
+def nparams(module):
+    if isinstance(module, (nn.QuantizedLinear, nn.QuantizedEmbedding)):
+        return module.weight.size * 32 // module.bits
+    return sum(v.size for _, v in tree_flatten(module.parameters()))
 
+
+def print_trainable_parameters(model):
     leaf_modules = tree_flatten(
         model.leaf_modules(), is_leaf=lambda m: isinstance(m, nn.Module)
     )

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -458,13 +458,14 @@ def load_model(
         weights = model.sanitize(weights)
 
     if (quantization := config.get("quantization", None)) is not None:
-        # Handle legacy models which may not have everything quantized
+
         def class_predicate(p, m):
             # Handle custom per layer quantizations
             if p in config["quantization"]:
                 return config["quantization"][p]
             if not hasattr(m, "to_quantized"):
                 return False
+            # Handle legacy models which may not have everything quantized
             return f"{p}.scales" in weights
 
         nn.quantize(

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -460,13 +460,17 @@ def load_model(
     if (quantization := config.get("quantization", None)) is not None:
         # Handle legacy models which may not have everything quantized
         def class_predicate(p, m):
+            # Handle custom per layer quantizations
+            if p in config["quantization"]:
+                return config["quantization"][p]
             if not hasattr(m, "to_quantized"):
                 return False
             return f"{p}.scales" in weights
 
         nn.quantize(
             model,
-            **quantization,
+            group_size=quantization["group_size"],
+            bits=quantization["bits"],
             class_predicate=class_predicate,
         )
 
@@ -669,7 +673,13 @@ def save_weights(
 
 
 def quantize_model(
-    model: nn.Module, config: dict, q_group_size: int, q_bits: int
+    model: nn.Module,
+    config: dict,
+    q_group_size: int,
+    q_bits: int,
+    quant_predicate: Optional[
+        Callable[[str, nn.Module, dict], Union[bool, dict]]
+    ] = None,
 ) -> Tuple:
     """
     Applies quantization to the model weights.
@@ -679,13 +689,31 @@ def quantize_model(
         config (dict): Model configuration.
         q_group_size (int): Group size for quantization.
         q_bits (int): Bits per weight for quantization.
+        quant_predicate (Callable): A callable that decides how
+            to quantize each layer based on the path.
+            Accepts the layer `path`, the `module` and the model `config`.
+            Returns either a bool to signify quantize/no quantize or
+            a dict of quantization parameters to pass to `to_quantized`.
 
     Returns:
         Tuple: Tuple containing quantized weights and config.
     """
     quantized_config = copy.deepcopy(config)
-    nn.quantize(model, q_group_size, q_bits)
     quantized_config["quantization"] = {"group_size": q_group_size, "bits": q_bits}
+
+    # Add any custom quantization parameters to the config as we go
+    def _class_predicate(p, m):
+        bool_or_params = quant_predicate(p, m, config)
+        if isinstance(bool_or_params, dict):
+            quantized_config["quantization"][p] = bool_or_params
+        return bool_or_params
+
+    nn.quantize(
+        model,
+        q_group_size,
+        q_bits,
+        class_predicate=_class_predicate if quant_predicate else None,
+    )
     # support hf model tree #957
     quantized_config["quantization_config"] = quantized_config["quantization"]
     quantized_weights = dict(tree_flatten(model.parameters()))
@@ -726,6 +754,9 @@ def convert(
     upload_repo: str = None,
     revision: Optional[str] = None,
     dequantize: bool = False,
+    quant_predicate: Optional[
+        Callable[[str, nn.Module, dict], Union[bool, dict]]
+    ] = None,
 ):
     # Check the save path is empty
     if isinstance(mlx_path, str):
@@ -751,7 +782,9 @@ def convert(
     if quantize:
         print("[INFO] Quantizing")
         model.load_weights(list(weights.items()))
-        weights, config = quantize_model(model, config, q_group_size, q_bits)
+        weights, config = quantize_model(
+            model, config, q_group_size, q_bits, quant_predicate=quant_predicate
+        )
 
     if dequantize:
         print("[INFO] Dequantizing")


### PR DESCRIPTION
Support passing a `quant_predicate` callable to `convert` that chooses a custom quantization for each layer in the model.

Example usage in [this gist](https://gist.github.com/barronalex/84addb8078be21969f1690c1454855f3).

## Benchmarks

Below is a comparison of the average accuracy across 8 `lm-eval` 0-shot reasoning tasks for a variety of our quants.
All experiments were conducted with Qwen2.5-7B-Instruct.

`arc_challenge`, `arc_easy`, `boolq`, `hellaswag`, `openbookqa`, `piqa`, `social_iqa`, `winogrande`

![quant](https://github.com/user-attachments/assets/f371c5aa-1044-420e-a8f0-b385ab84479a)

The full benchmarking script is [here](https://gist.github.com/barronalex/0f816636443ca7b6821f31ef488da2a6).

A few thoughts:
- For these tasks, anything from ~5bpw up seems to be around the full fp16 performance
- Mixed quants help, particularly for 3 bit, but you're much better off using n+1 bits with a larger group size if it fits
- There's a big drop off from 4->3 bit, trained quants are on the way which will address this :)
- Llama.cpp's Q4_K_M and our mixed 4/6 bit quant end up with almost identical results (the dots are overlapping). Benchmarking the llama.cpp k quant required some custom code to dequantize the quantized scales/biases which is in this [branch](https://github.com/ml-explore/mlx-examples/tree/load-gguf) and support for 16 group size at inference in this [branch](https://github.com/ml-explore/mlx/tree/gs16). I'm not planning to merge these since it's really inefficient but it's interesting to note that the double quantization doesn't seem to help much in this setting.