### PR TITLE
Fix shapes mismatch error in FluxPipeline.training_loss when batch-size >= 2

### DIFF
--- a/flux/flux/flux.py
+++ b/flux/flux/flux.py
@@ -208,9 +208,10 @@ class FluxPipeline:
         x_0, x_ids = self._prepare_latent_images(x_0)
 
         # Forward process
-        t = self.sampler.random_timesteps(*x_0.shape[:2], dtype=self.dtype)
-        eps = mx.random.normal(x_0.shape, dtype=self.dtype)
-        x_t = self.sampler.add_noise(x_0, t, noise=eps)
+        B, L = x_0.shape[:2]
+        t = self.sampler.random_timesteps(B, L, dtype=self.dtype)
+        eps = mx.random.normal(x_0.shape, dtype=x_0.dtype)
+        x_t = mx.stack([self.sampler.add_noise(x_0[idx], t[idx], noise=eps[idx]) for idx in range(B)])
         x_t = mx.stop_gradient(x_t)
 
         # Do the denoising

--- a/flux/flux/flux.py
+++ b/flux/flux/flux.py
@@ -208,10 +208,9 @@ class FluxPipeline:
         x_0, x_ids = self._prepare_latent_images(x_0)
 
         # Forward process
-        B, L = x_0.shape[:2]
-        t = self.sampler.random_timesteps(B, L, dtype=self.dtype)
-        eps = mx.random.normal(x_0.shape, dtype=x_0.dtype)
-        x_t = mx.stack([self.sampler.add_noise(x_0[idx], t[idx], noise=eps[idx]) for idx in range(B)])
+        t = self.sampler.random_timesteps(*x_0.shape[:2], dtype=self.dtype)
+        eps = mx.random.normal(x_0.shape, dtype=self.dtype)
+        x_t = self.sampler.add_noise(x_0, t, noise=eps)
         x_t = mx.stop_gradient(x_t)
 
         # Do the denoising

--- a/flux/flux/sampler.py
+++ b/flux/flux/sampler.py
@@ -50,6 +50,7 @@ class FluxSampler:
             if noise is not None
             else mx.random.normal(x.shape, dtype=x.dtype, key=key)
         )
+        t = t.reshape([-1] + [1] * (x.ndim - 1))
         return x * (1 - t) + t * noise
 
     def step(self, pred, x_t, t, t_prev):


### PR DESCRIPTION
Bug can be reproduced when training Flux with batch-size >= 2.

```shell
Traceback (most recent call last):
  File "/Volumes/Develop/MLX/mlx-examples/flux/dreambooth.py", line 267, in <module>
    loss, grads = step(*batch, guidance, grads, (i + 1) % args.grad_accumulate == 0)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Volumes/Develop/MLX/mlx-examples/flux/dreambooth.py", line 238, in step
    return single_step(x, t5_feat, clip_feat, guidance), None
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Volumes/Develop/MLX/mlx-examples/flux/dreambooth.py", line 195, in single_step
    loss, grads = nn.value_and_grad(flux.flow, flux.training_loss)(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/MLX/lib/python3.12/site-packages/mlx/nn/utils.py", line 35, in wrapped_value_grad_fn
    value, grad = value_grad_fn(model.trainable_parameters(), *args, **kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/MLX/lib/python3.12/site-packages/mlx/nn/utils.py", line 29, in inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/Volumes/Develop/MLX/mlx-examples/flux/flux/flux.py", line 213, in training_loss
    x_t = self.sampler.add_noise(x_0, t, noise=eps)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Volumes/Develop/MLX/mlx-examples/flux/flux/sampler.py", line 53, in add_noise
    return x * (1 - t) + t * noise
           ~~^~~~~~~~~
ValueError: Shapes (2,384,64) and (2) cannot be broadcast.

```

```python
t = self.sampler.random_timesteps(*x_0.shape[:2], dtype=self.dtype)
```

```python
x_t = self.sampler.add_noise(x_0, t, noise=eps)
```

When batch-size == 1, it works well since t will get shape=(1,).
But when batch-size >=2, it will cause shapes mismatch error .