### PR TITLE
fix missing --final-adapter-file crash in dreambooth.py

### DIFF
--- a/flux/dreambooth.py
+++ b/flux/dreambooth.py
@@ -289,4 +289,4 @@ if __name__ == "__main__":
             tic = time.time()
 
     save_adapters("final_adapters.safetensors", flux, args)
-    print(f"Training successful. Saved final weights to {args.adapter_file}.")
+    print("Training successful.")

--- a/flux/dreambooth.py
+++ b/flux/dreambooth.py
@@ -149,12 +149,6 @@ def setup_arg_parser():
         "--output-dir", default="mlx_output", help="Folder to save the checkpoints in"
     )
 
-    parser.add_argument(
-        "--final-adapter-file",
-        default="final_adapters.safetensors",
-        help="The file name in the output-dir of the final adapter including the extension .safetensors",
-    )
-
     parser.add_argument("dataset")
     return parser
 
@@ -294,5 +288,5 @@ if __name__ == "__main__":
             losses = []
             tic = time.time()
 
-    save_adapters(args.final_adapter_file, flux, args)
-    print(f"Training successful. Saved final weights to {args.final_adapter_file}.")
+    save_adapters("final_adapters.safetensors", flux, args)
+    print(f"Training successful. Saved final weights to {args.adapter_file}.")

--- a/flux/dreambooth.py
+++ b/flux/dreambooth.py
@@ -149,6 +149,12 @@ def setup_arg_parser():
         "--output-dir", default="mlx_output", help="Folder to save the checkpoints in"
     )
 
+    parser.add_argument(
+        "--final-adapter-file",
+        default="final_adapters.safetensors",
+        help="The file name in the output-dir of the final adapter including the extension .safetensors",
+    )
+
     parser.add_argument("dataset")
     return parser
 
@@ -288,5 +294,5 @@ if __name__ == "__main__":
             losses = []
             tic = time.time()
 
-    save_adapters("final_adapters.safetensors", flux, args)
-    print(f"Training successful. Saved final weights to {args.adapter_file}.")
+    save_adapters(args.final_adapter_file, flux, args)
+    print(f"Training successful. Saved final weights to {args.final_adapter_file}.")


### PR DESCRIPTION
This fixes a crash I spotted at the very end of the `dreambooth.py` example in the `flux` directory.

The code assumed a command line argument was passed in but then always saved to `final_adapters.safetensors`  I think this addresses the issue.