### PR TITLE
Add a fix for special added tokens

### DIFF
--- a/llms/mlx_lm/tokenizer_utils.py
+++ b/llms/mlx_lm/tokenizer_utils.py
@@ -167,6 +167,8 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
 
     def __init__(self, tokenizer):
 
+        self.tokenizer = tokenizer
+
         self.clean_spaces = tokenizer.clean_up_tokenization_spaces
 
         # Extract the tokens in a list from id to text
@@ -208,6 +210,9 @@ class BPEStreamingDetokenizer(StreamingDetokenizer):
             ).decode("utf-8")
             self.text += self._maybe_trim_space(current_text)
             if is_added:
+                # We need to manually encode and decode the added tokens in case special characters
+                # used for `\n` / `\t` have been manually added in the added tokens
+                v = self.tokenizer.decode(self.tokenizer.encode(v))
                 self.text += v
                 self._unflushed = ""
             else:


### PR DESCRIPTION

This PR fixes the decoding of manually added tokens such as `\n` in this case. The latter is getting decoded as `Ċ`. 

### Generation before the fix:
```
Prompt: Once upon a time in a land far away,
there was a kingdom ruled by a wise and just king. The kingdom was known for its beauty and prosperity, and the people lived in peace and harmony.ĊĊOne day, a terrible drought struck the land, and the crops began to wither and die. The king, worried about the well-being of his people, called upon his wise council to find a solution. The council, after much deliberation, decided to send a group of brave knights to search for a magical spring that was said to have the power to bring rain to the kingdom.
```

### Generation after the fix:
```
Prompt: Once upon a time in a land far away,
there was a kingdom ruled by a wise and just king. The kingdom was known for its beauty and prosperity, and the people lived in peace and harmony.

One day, a terrible drought struck the land, and the crops began to wither and die. The king, worried about the well-being of his people, called upon his wise council to find a solution. The council, after much deliberation, decided to send a group of brave knights to search for a magical spring that was said to have the power to bring rain to the kingdom.
```