### PR TITLE
Add support for fewshot and apply chat template lm_eval functionality

### DIFF
--- a/llms/mlx_lm/evaluate.py
+++ b/llms/mlx_lm/evaluate.py
@@ -79,6 +79,9 @@ class MLXLM(LM):
         self._model, self._tokenizer = load(path_or_hf_repo)
         self._max_tokens = max_tokens or self._tokenizer.model_max_length
 
+        # Needed by HF implementation methods (tokenizer_name, apply_chat_template, and, tok_encode)
+        self.tokenizer = self._tokenizer
+
     def _score_fn(self, inputs, tokenize=True, step_size=32):
         if tokenize:
             inputs = self._tokenizer.encode(inputs)
@@ -216,6 +219,10 @@ class MLXLM(LM):
             tokenize=False,
         )
         return [(r[0], r[1] == r[2]) for r in results]
+
+    tokenizer_name = lm_eval.models.huggingface.HFLM.tokenizer_name
+    apply_chat_template = lm_eval.models.huggingface.HFLM.apply_chat_template
+    tok_encode = lm_eval.models.huggingface.HFLM.tok_encode
 
     def loglikelihood_rolling(self, requests) -> list[float]:
         """Compute full log-likelihood of a string, with no truncation, for perplexity computation

--- a/llms/mlx_lm/evaluate.py
+++ b/llms/mlx_lm/evaluate.py
@@ -322,6 +322,18 @@ def main():
         help="Maximum nunber of tokens to generate. Defaults to the model's max context length.",
     )
     parser.add_argument("--seed", type=int, default=123, help="Random seed.")
+    parser.add_argument(
+        "--fewshot-as-multiturn",
+        action="store_true",
+        help="Whether to provide the fewshot examples as a multiturn conversation or a single user turn.",
+        default=False,
+    )
+    parser.add_argument(
+        "--apply-chat-template",
+        action="store_true",
+        help="Specifies whether to apply a chat template to the prompt",
+        default=False,
+    )
     args = parser.parse_args()
 
     output_dir = Path(args.output_dir)
@@ -337,6 +349,8 @@ def main():
     results = lm_eval.simple_evaluate(
         model=lm,
         tasks=args.tasks,
+        fewshot_as_multiturn=args.fewshot_as_multiturn,
+        apply_chat_template=args.apply_chat_template,
         num_fewshot=args.num_shots,
         random_seed=args.seed,
         numpy_random_seed=args.seed,


### PR DESCRIPTION
Adds `--fewshot-as-multiturn` and `--apply-chat-template` to script, which correspond to lm_eval options of similar names and very often used to ensure apples-to-apples comparisons of lm_evaluation results