### PR TITLE
Use upload_large_folder

### DIFF
--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -673,12 +673,10 @@ def upload_to_hub(path: str, upload_repo: str, hf_path: str):
 
     api = HfApi()
     api.create_repo(repo_id=upload_repo, exist_ok=True)
-    api.upload_folder(
+    api.upload_large_folder(
         folder_path=path,
         repo_id=upload_repo,
         repo_type="model",
-        multi_commits=True,
-        multi_commits_verbose=True,
     )
     print(f"Upload successful, go to https://huggingface.co/{upload_repo} for details.")
 


### PR DESCRIPTION
There are in my opinion two reasons to use `upload_large_folder` instead of `upload_folder`:

- The `multi_commits` args are no longer supported by `upload_folder`. Attempting to convert and upload a model with a recent version of `huggingface_hub` will fail. This includes a new install of `mlx-lm` in an empty environment.
- `upload_large_folder` is more efficient and resilient than `upload_folder`. There are also [some limitations](https://huggingface.co/docs/huggingface_hub/v0.27.1/en/package_reference/hf_api#huggingface_hub.HfApi.upload_large_folder), but I think they don't apply here.
