### PR TITLE
fix(lora): config yaml & arg default merge bug

### DIFF
--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -58,6 +58,8 @@ CONFIG_DEFAULTS = {
     "test": False,
     "test_batches": 500,
     "max_seq_length": 2048,
+    "config": None,
+    "grad_checkpoint": False,
     "lr_schedule": None,
     "lora_parameters": {"rank": 8, "alpha": 16, "dropout": 0.0, "scale": 10.0},
 }
@@ -67,6 +69,7 @@ def build_parser():
     parser = argparse.ArgumentParser(description="LoRA or QLoRA finetuning.")
     parser.add_argument(
         "--model",
+        type=str,
         help="The path to the local model directory or Hugging Face repo.",
     )
 
@@ -75,7 +78,6 @@ def build_parser():
         "--train",
         action="store_true",
         help="Do training",
-        default=None,
     )
     parser.add_argument(
         "--data",
@@ -89,7 +91,6 @@ def build_parser():
         "--fine-tune-type",
         type=str,
         choices=["lora", "dora", "full"],
-        default="lora",
         help="Type of fine-tuning to perform: lora, dora, or full.",
     )
     parser.add_argument(
@@ -134,7 +135,6 @@ def build_parser():
         "--test",
         action="store_true",
         help="Evaluate on the test set after training",
-        default=None,
     )
     parser.add_argument(
         "--test-batches",
@@ -149,16 +149,15 @@ def build_parser():
     parser.add_argument(
         "-c",
         "--config",
-        default=None,
+        type=str,
         help="A YAML configuration file with the training options",
     )
     parser.add_argument(
         "--grad-checkpoint",
         action="store_true",
         help="Use gradient checkpointing to reduce memory use.",
-        default=None,
     )
-    parser.add_argument("--seed", type=int, default=None, help="The PRNG seed")
+    parser.add_argument("--seed", type=int, help="The PRNG seed")
     return parser
 
 


### PR DESCRIPTION
currently, cli arg defaults overwrite lora config yaml

```bash
cat config.yaml | grep fine_tune_type
fine_tune_type: full

mlx_lm.lora --config config.yaml
...

cat adapters/adapter_config.json | grep fine_tune_type
"fine_tune_type": "lora",
```

setting the cli arg overwrites the config yaml as expected but should not be necessary

```bash
cat config.yaml | grep fine_tune_type
fine_tune_type: full

mlx_lm.lora --config config.yaml --fine-tune-type full
...

cat adapters/adapter_config.json | grep fine_tune_type
"fine_tune_type": "full",
```

after these changes the config yaml can be used as expected

```bash
cat config.yaml | grep fine_tune_type
fine_tune_type: full

mlx_lm.lora --config config.yaml
...

cat adapters/adapter_config.json | grep fine_tune_type
"fine_tune_type": "full",
```

cli arg overwriting config yaml should continue to work as well

```bash
cat config.yaml | grep fine_tune_type
fine_tune_type: full

mlx_lm.lora --config config.yaml --fine-tune-type lora
...

cat adapters/adapter_config.json | grep fine_tune_type
"fine_tune_type": "lora",
```

changes:
- remove all cli arg defaults
  - `default=None` works as expected but removing for consistency and clarity
- add missing `CONFIG_DEFAULTS`
  - `"config": None` & `"grad_checkpoint": False`
- add missing `type=str` to args
  - not actually necessary but maintains consistency and the pattern is used elsewhere