### PR TITLE
Fix Cohere2: mask shape error (long context)

### DIFF
--- a/llms/mlx_lm/models/base.py
+++ b/llms/mlx_lm/models/base.py
@@ -42,13 +42,13 @@ def create_causal_mask(
     return mask * -1e9
 
 
-def create_attention_mask(h: mx.array, cache: Optional[Any] = None, layer_idx: int = 0):
+def create_attention_mask(h: mx.array, cache: Optional[Any] = None):
     T = h.shape[1]
     if T > 1:
         window_size = None
         offset = 0
-        if cache is not None and cache[layer_idx] is not None:
-            c = cache[layer_idx]
+        if cache is not None and cache[0] is not None:
+            c = cache[0]
             if hasattr(c, "max_size"):
                 offset = min(c.max_size, c.offset)
                 window_size = c.max_size

--- a/llms/mlx_lm/models/base.py
+++ b/llms/mlx_lm/models/base.py
@@ -42,13 +42,13 @@ def create_causal_mask(
     return mask * -1e9
 
 
-def create_attention_mask(h: mx.array, cache: Optional[Any] = None):
+def create_attention_mask(h: mx.array, cache: Optional[Any] = None, layer_idx: int = 0):
     T = h.shape[1]
     if T > 1:
         window_size = None
         offset = 0
-        if cache is not None and cache[0] is not None:
-            c = cache[0]
+        if cache is not None and cache[layer_idx] is not None:
+            c = cache[layer_idx]
             if hasattr(c, "max_size"):
                 offset = min(c.max_size, c.offset)
                 window_size = c.max_size

--- a/llms/mlx_lm/models/cohere2.py
+++ b/llms/mlx_lm/models/cohere2.py
@@ -158,7 +158,7 @@ class CohereModel(nn.Module):
 
         if mask is None:
             j = self.args.sliding_window_pattern
-            mask = create_attention_mask(h, cache[j - 1: j])
+            mask = create_attention_mask(h, cache[j - 1 : j])
 
         if cache is None:
             cache = [None] * len(self.layers)

--- a/llms/mlx_lm/models/cohere2.py
+++ b/llms/mlx_lm/models/cohere2.py
@@ -157,7 +157,8 @@ class CohereModel(nn.Module):
         h = self.embed_tokens(inputs)
 
         if mask is None:
-            mask = create_attention_mask(h, cache, layer_idx=self.args.sliding_window_pattern - 1)
+            j = self.args.sliding_window_pattern
+            mask = create_attention_mask(h, cache[j - 1: j])
 
         if cache is None:
             cache = [None] * len(self.layers)

--- a/llms/mlx_lm/models/cohere2.py
+++ b/llms/mlx_lm/models/cohere2.py
@@ -156,12 +156,12 @@ class CohereModel(nn.Module):
     ):
         h = self.embed_tokens(inputs)
 
+        if cache is None:
+            cache = [None] * len(self.layers)
+            
         if mask is None:
             j = self.args.sliding_window_pattern
             mask = create_attention_mask(h, cache[j - 1 : j])
-
-        if cache is None:
-            cache = [None] * len(self.layers)
 
         for layer, c in zip(self.layers, cache):
             h = layer(h, mask, c)

--- a/llms/mlx_lm/models/cohere2.py
+++ b/llms/mlx_lm/models/cohere2.py
@@ -157,7 +157,7 @@ class CohereModel(nn.Module):
         h = self.embed_tokens(inputs)
 
         if mask is None:
-            mask = create_attention_mask(h, cache)
+            mask = create_attention_mask(h, cache, layer_idx=self.args.sliding_window_pattern - 1)
 
         if cache is None:
             cache = [None] * len(self.layers)

--- a/llms/mlx_lm/models/cohere2.py
+++ b/llms/mlx_lm/models/cohere2.py
@@ -158,7 +158,7 @@ class CohereModel(nn.Module):
 
         if cache is None:
             cache = [None] * len(self.layers)
-            
+
         if mask is None:
             j = self.args.sliding_window_pattern
             mask = create_attention_mask(h, cache[j - 1 : j])


### PR DESCRIPTION
## Bug Description
PR #1173 introduced a shape mismatch error in the Cohere2 attention mask when processing contexts larger than 4K tokens. The issue stems from incorrect cache indexing in the attention mask creation.

Reported [here](https://x.com/ivanmeallares/status/1878140524093125076).

## Root Cause
The `create_attention_mask` function was using a hardcoded index (`cache[0]`) to access cache information, instead of using the appropriate layer-specific index. This caused incorrect offset calculations for sliding window patterns in deeper layers.

## Fix
- Added `layer_idx` parameter to `create_attention_mask` with default value 0.
- Modified cache access to use `cache[layer_idx]` instead of `cache[0]`
- Updated Cohere2 model to pass the correct layer index based on sliding window pattern

## Validation
Tested with context length of 16,539 tokens:
- Before: Shape mismatch error in attention mask calculation
- After: Successfully processes large contexts with correct mask shapes

## Screenshots
### Before Fix
```
mask shape (512, 4096)
queries shape (1, 32, 512, 128)
keys shape (1, 8, 4096, 128)
values shape (1, 8, 4096, 128)
======
mask shape (512, 4608) -> mismatch ❌
queries shape (1, 32, 512, 128)
keys shape (1, 8, 5120, 128)
values shape (1, 8, 5120, 128)
```
<img width="1502" alt="Screenshot 2025-01-11 at 9 35 55 PM" src="https://github.com/user-attachments/assets/06bd7e74-b326-4d41-aa1f-699fd76ebe8f" />

### After Fix
<img width="1503" alt="Screenshot 2025-01-11 at 9 33 58 PM" src="https://github.com/user-attachments/assets/27afb62f-a4e6-4c83-b96d-54f64c41a086" />