### PR TITLE
fix(lora): add back store_true default args

### DIFF
--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -78,6 +78,7 @@ def build_parser():
         "--train",
         action="store_true",
         help="Do training",
+        default=None,
     )
     parser.add_argument(
         "--data",
@@ -135,6 +136,7 @@ def build_parser():
         "--test",
         action="store_true",
         help="Evaluate on the test set after training",
+        default=None,
     )
     parser.add_argument(
         "--test-batches",
@@ -156,6 +158,7 @@ def build_parser():
         "--grad-checkpoint",
         action="store_true",
         help="Use gradient checkpointing to reduce memory use.",
+        default=None,
     )
     parser.add_argument("--seed", type=int, help="The PRNG seed")
     return parser


### PR DESCRIPTION
sorry! i did not test https://github.com/ml-explore/mlx-examples/pull/1196 well enough and caused an issue when trying to clean up default args

currently cli args with `action="store_true"` are not overwritten by config yaml because they are set to `False` instead of `None`
https://github.com/ml-explore/mlx-examples/blob/c117af83b8cbec15523bd0d69e7a57f01237ca89/llms/mlx_lm/lora.py#L289-L291

this results in needing to set `--train`, `--test`, and `--grad-checkpoint` via cli as config yaml is not respected

setting `default=None` on these args fixes the issue