### PR TITLE
Fix dataset variable name, in `datasets.py`

### DIFF
--- a/llms/mlx_lm/tuner/datasets.py
+++ b/llms/mlx_lm/tuner/datasets.py
@@ -170,7 +170,7 @@ def load_custom_hf_dataset(args, tokenizer: PreTrainedTokenizer):
         if prompt_feature and completion_feature:
             return CompletionsDataset(ds, tokenizer, prompt_feature, completion_feature)
         elif text_feature:
-            return Dataset(train_ds, tokenizer, text_key=text_feature)
+            return Dataset(ds, tokenizer, text_key=text_feature)
         else:
             raise ValueError(
                 "Specify either a prompt and completion feature or a text "


### PR DESCRIPTION
Fixes the error `NameError: name 'train_ds' is not defined`, which is currently thrown when using a configuration like this for the LORA tuner:

```yml
hf_dataset:
  name: "OpenAssistant/oasst_top1_2023-08-25"
  train_split: "train"
  valid_split: "test"
  text_feature: "text"
```