### PR TITLE
whisper: add directory transcription support

### DIFF
--- a/whisper/README.md
+++ b/whisper/README.md
@@ -31,6 +31,11 @@ mlx_whisper audio_file.mp3
 
 This will make a text file `audio_file.txt` with the results.
 
+You can also transcribe a directory of audio files:
+```sh
+mlx_whisper path/to/directory/
+```
+
 Use `-f` to specify the output format and `--model` to specify the model. There
 are many other supported command line options. To see them all, run
 `mlx_whisper -h`.


### PR DESCRIPTION
Add support for transcribing all files in a directory recursively. The implementation lets ffmpeg handle file validation instead of filtering by extension. Update README with minimal documentation for directory support.