### PR TITLE
chore(mlx-lm): support text type content in messages

### DIFF
--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -133,15 +133,15 @@ def process_message_content(messages):
     processed_messages = []
     for message in messages:
         message_copy = message.copy()
-        if "content" in message_copy:
-            flattened_text = ""
-            if isinstance(message_copy["content"], list):
-                for content_fragment in message_copy["content"]:
-                    if content_fragment["type"] == "text" and "text" in content_fragment:
-                        flattened_text += content_fragment["text"]
-                    else:
-                        raise ValueError("Only 'text' content type is supported.")
-            message_copy["content"] = flattened_text
+        if "content" in message_copy and isinstance(message_copy["content"], list):
+            text_fragments = [
+                fragment["text"]
+                for fragment in message_copy["content"]
+                if fragment.get("type") == "text"
+            ]
+            if len(text_fragments) != len(message_copy["content"]):
+                raise ValueError("Only 'text' content type is supported.")
+            message_copy["content"] = "".join(text_fragments)
         processed_messages.append(message_copy)
     return processed_messages
 

--- a/llms/tests/test_server.py
+++ b/llms/tests/test_server.py
@@ -79,7 +79,31 @@ class TestServer(unittest.TestCase):
         response_body = response.text
         self.assertIn("id", response_body)
         self.assertIn("choices", response_body)
-
+        
+    def test_handle_chat_completions_with_content_fragments(self):
+        url = f"http://localhost:{self.port}/v1/chat/completions"
+        chat_post_data = {
+            "model": "chat_model", 
+            "max_tokens": 10,
+            "temperature": 0.7,
+            "top_p": 0.85,
+            "repetition_penalty": 1.2,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": "You are a helpful assistant."}]
+                },
+                {
+                    "role": "user", 
+                    "content": [{"type": "text", "text": "Hello!"}]
+                }
+            ]
+        }
+        response = requests.post(url, json=chat_post_data)
+        response_body = response.text
+        self.assertIn("id", response_body)
+        self.assertIn("choices", response_body)
+        
     def test_handle_models(self):
         url = f"http://localhost:{self.port}/v1/models"
         response = requests.get(url)

--- a/llms/tests/test_server.py
+++ b/llms/tests/test_server.py
@@ -79,11 +79,11 @@ class TestServer(unittest.TestCase):
         response_body = response.text
         self.assertIn("id", response_body)
         self.assertIn("choices", response_body)
-        
+
     def test_handle_chat_completions_with_content_fragments(self):
         url = f"http://localhost:{self.port}/v1/chat/completions"
         chat_post_data = {
-            "model": "chat_model", 
+            "model": "chat_model",
             "max_tokens": 10,
             "temperature": 0.7,
             "top_p": 0.85,
@@ -91,19 +91,18 @@ class TestServer(unittest.TestCase):
             "messages": [
                 {
                     "role": "system",
-                    "content": [{"type": "text", "text": "You are a helpful assistant."}]
+                    "content": [
+                        {"type": "text", "text": "You are a helpful assistant."}
+                    ],
                 },
-                {
-                    "role": "user", 
-                    "content": [{"type": "text", "text": "Hello!"}]
-                }
-            ]
+                {"role": "user", "content": [{"type": "text", "text": "Hello!"}]},
+            ],
         }
         response = requests.post(url, json=chat_post_data)
         response_body = response.text
         self.assertIn("id", response_body)
         self.assertIn("choices", response_body)
-        
+
     def test_handle_models(self):
         url = f"http://localhost:{self.port}/v1/models"
         response = requests.get(url)


### PR DESCRIPTION
In the latest version of SmolAgents, it has started using message content fragments formatted as `content = { type: 'text', content: 'hello world' }` instead of using a string for the text content. This change breaks compatibility with the mlx-lm.server. To make the mlx-lm server compatible with this new format,  added to convert content from text fragments to text strings in order to apply chat template.

![Screenshot 2025-01-27 at 12 09 55 am](https://github.com/user-attachments/assets/c914e343-c23c-40c4-97c0-5d1bd4db14f3)

After fixing, we can use mlx-lm.server with smolagents as shown below:
```py
from smolagents import CodeAgent, OpenAIServerModel

model = OpenAIServerModel(
    api_base="http://<your-mlx-server>:8080",
    api_key="n/a",
    model_id="default_model",
    temperature=0,
    max_tokens=8000,
)

agent = CodeAgent(tools=[], model=model, add_base_tools=True)

agent.run(
    "How many seconds would it take for a leopard at full speed to run through Pont des Arts?"
)
```