### PR TITLE
Bug fix - enabling Qwen2 support

### DIFF
--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -73,13 +73,6 @@ def build_parser():
         help="The path to the local model directory or Hugging Face repo.",
     )
 
-    parser.add_argument(
-        "--revision",
-        default="main",
-        type=str,
-        help="Hash value of the commit to checkout from the Hugging Face repo.",
-    )
-
     # Training args
     parser.add_argument(
         "--train",
@@ -259,7 +252,7 @@ def run(args, training_callback: TrainingCallback = None):
     np.random.seed(args.seed)
 
     print("Loading pretrained model")
-    model, tokenizer = load(args.model, args.revision)
+    model, tokenizer = load(args.model)
 
     print("Loading datasets")
     train_set, valid_set, test_set = load_dataset(args, tokenizer)

--- a/llms/mlx_lm/lora.py
+++ b/llms/mlx_lm/lora.py
@@ -73,6 +73,13 @@ def build_parser():
         help="The path to the local model directory or Hugging Face repo.",
     )
 
+    parser.add_argument(
+        "--revision",
+        default="main",
+        type=str,
+        help="Hash value of the commit to checkout from the Hugging Face repo.",
+    )
+
     # Training args
     parser.add_argument(
         "--train",
@@ -252,7 +259,7 @@ def run(args, training_callback: TrainingCallback = None):
     np.random.seed(args.seed)
 
     print("Loading pretrained model")
-    model, tokenizer = load(args.model)
+    model, tokenizer = load(args.model, args.revision)
 
     print("Loading datasets")
     train_set, valid_set, test_set = load_dataset(args, tokenizer)

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -153,7 +153,7 @@ def compute_bits_per_weight(model):
     return model_bytes * 8 / model_params
 
 
-def get_model_path(path_or_hf_repo: str, revision: Optional[str] = "main") -> Path:
+def get_model_path(path_or_hf_repo: str, revision: Optional[str] = None) -> Path:
     """
     Ensures the model is available locally. If the path does not exist locally,
     it is downloaded from the Hugging Face Hub.
@@ -185,7 +185,7 @@ def get_model_path(path_or_hf_repo: str, revision: Optional[str] = "main") -> Pa
             )
         except:
             raise ModelNotFoundError(
-                f"Model not found for path or HF repo: {path_or_hf_repo}:{revision}.\n"
+                f"Model not found for path or HF repo: {path_or_hf_repo}.\n"
                 "Please make sure you specified the local path or Hugging Face"
                 " repo id correctly.\nIf you are trying to access a private or"
                 " gated Hugging Face repo, make sure you are authenticated:\n"
@@ -710,7 +710,6 @@ def load(
     model_config={},
     adapter_path: Optional[str] = None,
     lazy: bool = False,
-    revision: Optional[str] = "main",
 ) -> Tuple[nn.Module, TokenizerWrapper]:
     """
     Load the model and tokenizer from a given path or a huggingface repository.

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -709,7 +709,7 @@ def load(
     model_config={},
     adapter_path: Optional[str] = None,
     lazy: bool = False,
-    commit_hash: Optional[str] = "main",
+    revision: Optional[str] = "main",
 ) -> Tuple[nn.Module, TokenizerWrapper]:
     """
     Load the model and tokenizer from a given path or a huggingface repository.

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -43,7 +43,7 @@ MODEL_REMAPPING = {
     "mistral": "llama",  # mistral is compatible with llama
     "phi-msft": "phixtral",
     "falcon_mamba": "mamba",
-    "qwen2": "qwen2",
+    "qwen2": "qwen2"
 }
 
 MAX_FILE_SIZE_GB = 5

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -152,7 +152,7 @@ def compute_bits_per_weight(model):
     return model_bytes * 8 / model_params
 
 
-def get_model_path(path_or_hf_repo: str, revision: Optional[str] = None) -> Path:
+def get_model_path(path_or_hf_repo: str, revision: Optional[str] = "main") -> Path:
     """
     Ensures the model is available locally. If the path does not exist locally,
     it is downloaded from the Hugging Face Hub.
@@ -184,7 +184,7 @@ def get_model_path(path_or_hf_repo: str, revision: Optional[str] = None) -> Path
             )
         except:
             raise ModelNotFoundError(
-                f"Model not found for path or HF repo: {path_or_hf_repo}.\n"
+                f"Model not found for path or HF repo: {path_or_hf_repo}:{revision}.\n"
                 "Please make sure you specified the local path or Hugging Face"
                 " repo id correctly.\nIf you are trying to access a private or"
                 " gated Hugging Face repo, make sure you are authenticated:\n"
@@ -709,6 +709,7 @@ def load(
     model_config={},
     adapter_path: Optional[str] = None,
     lazy: bool = False,
+    commit_hash: Optional[str] = "main",
 ) -> Tuple[nn.Module, TokenizerWrapper]:
     """
     Load the model and tokenizer from a given path or a huggingface repository.

--- a/llms/mlx_lm/utils.py
+++ b/llms/mlx_lm/utils.py
@@ -43,6 +43,7 @@ MODEL_REMAPPING = {
     "mistral": "llama",  # mistral is compatible with llama
     "phi-msft": "phixtral",
     "falcon_mamba": "mamba",
+    "qwen2": "qwen2",
 }
 
 MAX_FILE_SIZE_GB = 5


### PR DESCRIPTION
Just added `qwen2` in `MODEL_MAPPING` in `utils.py`, so `mlx_lm.models.qwen2` can be successfully imported. Tested this out with `mlx-community/Unsloth-DeepSeek-R1-Distill-Qwen-32B-4bit` on HF.