### PR TITLE
Remove temp argument

### DIFF
--- a/llms/mlx_lm/examples/chat.py
+++ b/llms/mlx_lm/examples/chat.py
@@ -23,7 +23,6 @@ response = generate(
     tokenizer,
     prompt=prompt,
     verbose=True,
-    temp=0.0,
     prompt_cache=prompt_cache,
 )
 


### PR DESCRIPTION
Currently, the `temp` argument [here](https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/examples/chat.py#L26) causes the `generate()` to fail with the following error:
`TypeError: generate_step() got an unexpected keyword argument 'temp'`

Removal of this deprecated argument fixes it. 

cc @awni 