### PR TITLE
Add support for IPv6 server

### DIFF
--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -8,7 +8,8 @@ import time
 import uuid
 import warnings
 from dataclasses import dataclass, field
-from http.server import BaseHTTPRequestHandler, HTTPServer, _get_best_family
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import socket
 from pathlib import Path
 from typing import (
     Any,
@@ -694,7 +695,7 @@ def run(
 ):
     server_address = (host, port)
     prompt_cache = PromptCache()
-    server_class.address_family, server_address = _get_best_family(*server_address)
+    server_class.address_family, _, _, _, server_address = next(iter(socket.getaddrinfo(*server_address, type=socket.SOCK_STREAM, flags=socket.AI_PASSIVE)))
     httpd = server_class(
         server_address,
         lambda *args, **kwargs: handler_class(

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -4,12 +4,12 @@ import argparse
 import json
 import logging
 import platform
+import socket
 import time
 import uuid
 import warnings
 from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, HTTPServer
-import socket
 from pathlib import Path
 from typing import (
     Any,
@@ -696,9 +696,7 @@ def run(
     server_address = (host, port)
     prompt_cache = PromptCache()
     infos = socket.getaddrinfo(
-        *server_address,
-        type=socket.SOCK_STREAM,
-        flags=socket.AI_PASSIVE
+        *server_address, type=socket.SOCK_STREAM, flags=socket.AI_PASSIVE
     )
     server_class.address_family, _, _, _, server_address = next(iter(infos))
     httpd = server_class(

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -695,7 +695,12 @@ def run(
 ):
     server_address = (host, port)
     prompt_cache = PromptCache()
-    server_class.address_family, _, _, _, server_address = next(iter(socket.getaddrinfo(*server_address, type=socket.SOCK_STREAM, flags=socket.AI_PASSIVE)))
+    infos = socket.getaddrinfo(
+        *server_address,
+        type=socket.SOCK_STREAM,
+        flags=socket.AI_PASSIVE
+    )
+    server_class.address_family, _, _, _, server_address = next(iter(infos))
     httpd = server_class(
         server_address,
         lambda *args, **kwargs: handler_class(

--- a/llms/mlx_lm/server.py
+++ b/llms/mlx_lm/server.py
@@ -8,7 +8,7 @@ import time
 import uuid
 import warnings
 from dataclasses import dataclass, field
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer, _get_best_family
 from pathlib import Path
 from typing import (
     Any,
@@ -694,6 +694,7 @@ def run(
 ):
     server_address = (host, port)
     prompt_cache = PromptCache()
+    server_class.address_family, server_address = _get_best_family(*server_address)
     httpd = server_class(
         server_address,
         lambda *args, **kwargs: handler_class(


### PR DESCRIPTION
http.server supports IPv6, but the address has to be processed by `socket.getaddrinfo`. This will fix errors when running mlx_lm.server with IPv6 server addresses (e.g. ::).