### PR TITLE
chore(lora): Add real-time log buffering fix for nohup execution

### DIFF
--- a/lora/lora.py
+++ b/lora/lora.py
@@ -1,9 +1,9 @@
 # Copyright © 2023-2024 Apple Inc.
 
-import sys
 import argparse
 import json
 import math
+import sys
 import time
 from pathlib import Path
 
@@ -14,7 +14,6 @@ import numpy as np
 import utils as lora_utils
 from mlx.utils import tree_flatten
 from models import LoRALinear
-
 
 # Disable output buffering to see print statements in real-time
 sys.stdout.reconfigure(line_buffering=True)

--- a/lora/lora.py
+++ b/lora/lora.py
@@ -1,6 +1,5 @@
 # Copyright © 2023-2024 Apple Inc.
 
-import os
 import sys
 import argparse
 import json
@@ -18,10 +17,8 @@ from models import LoRALinear
 
 
 # Disable output buffering to see print statements in real-time
-if sys.version_info >= (3, 7):
-    sys.stdout.reconfigure(line_buffering=True)
-else:
-    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 1)
+sys.stdout.reconfigure(line_buffering=True)
+
 
 def build_parser():
     parser = argparse.ArgumentParser(description="LoRA or QLoRA finetuning.")

--- a/lora/lora.py
+++ b/lora/lora.py
@@ -1,5 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
+import os
+import sys
 import argparse
 import json
 import math
@@ -14,6 +16,12 @@ import utils as lora_utils
 from mlx.utils import tree_flatten
 from models import LoRALinear
 
+
+# Disable output buffering to see print statements in real-time
+if sys.version_info >= (3, 7):
+    sys.stdout.reconfigure(line_buffering=True)
+else:
+    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 1)
 
 def build_parser():
     parser = argparse.ArgumentParser(description="LoRA or QLoRA finetuning.")


### PR DESCRIPTION
Fixes issue where nohup.out only shows logs after script completion, making real-time monitoring impossible. Detects Python version and applies appropriate buffering fix.