### PR TITLE
Use a bool mask for attention

### DIFF
--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -152,7 +152,7 @@ def setup_arg_parser():
         "--num-draft-tokens",
         type=int,
         help="Number of tokens to draft when using speculative decoding.",
-        default=2,
+        default=3,
     )
     return parser
 

--- a/llms/mlx_lm/models/base.py
+++ b/llms/mlx_lm/models/base.py
@@ -33,13 +33,13 @@ def create_causal_mask(
     linds = mx.arange(offset, offset + N) if offset else rinds
     linds = linds[:, None]
     rinds = rinds[None]
-    mask = linds < rinds
+    mask = linds >= rinds
     if window_size is not None:
-        mask = mask | (linds > rinds + window_size)
+        mask = mask & (linds <= rinds + window_size)
     if lengths is not None:
         lengths = lengths[:, None, None, None]
-        mask = mask | (rinds >= lengths)
-    return mask * -1e9
+        mask = mask & (rinds < lengths)
+    return mask
 
 
 def create_attention_mask(h: mx.array, cache: Optional[Any] = None):
@@ -55,7 +55,6 @@ def create_attention_mask(h: mx.array, cache: Optional[Any] = None):
             else:
                 offset = c.offset
         mask = create_causal_mask(T, offset, window_size=window_size)
-        mask = mask.astype(h.dtype)
     else:
         mask = None
     return mask


### PR DESCRIPTION
This let's us route to SDPA for some cases where it is supported especially after https://github.com/ml-explore/mlx/pull/1922 lands.

This + 1922 speeds things up with speculative decoding. Benchmarks on M4 Max:

```
mlx_lm.generate --model mlx-community/Qwen2.5-32B-Instruct-4bit --draft-model mlx-community/Qwen2.5-0.5B-Instruct-4bit --prompt "Write a very long quick sort in C++ followed by a very long merge sort. Then do the same in Python." -m 4096 --num-draft-tokens 3
```

Pre: Generation: 1172 tokens, 37.347 tokens-per-sec
Post: Generation: 1172 tokens, 41.503 tokens-per-sec

And for a much longer prompt:
Pre:

```
Prompt: 35371 tokens, 123.414 tokens-per-sec
Generation: 512 tokens, 6.749 tokens-per-sec
Peak memory: 33.348 GB
```

Post:

```
Prompt: 35371 tokens, 127.796 tokens-per-sec
Generation: 512 tokens, 13.821 tokens-per-sec
Peak memory: 31.800 GB
```