### PR TITLE
Change DEFAULT_SEED to None for stochastic generation by default

### DIFF
--- a/llms/mlx_lm/chat.py
+++ b/llms/mlx_lm/chat.py
@@ -11,7 +11,7 @@ from .utils import load, stream_generate
 
 DEFAULT_TEMP = 0.0
 DEFAULT_TOP_P = 1.0
-DEFAULT_SEED = 0
+DEFAULT_SEED = None
 DEFAULT_MAX_TOKENS = 256
 DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
 
@@ -36,7 +36,12 @@ def setup_arg_parser():
     parser.add_argument(
         "--top-p", type=float, default=DEFAULT_TOP_P, help="Sampling top-p"
     )
-    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="PRNG seed")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_SEED,
+        help="PRNG seed (default: use MLX's time-based RNG)",
+    )
     parser.add_argument(
         "--max-kv-size",
         type=int,
@@ -57,7 +62,8 @@ def main():
     parser = setup_arg_parser()
     args = parser.parse_args()
 
-    mx.random.seed(args.seed)
+    if args.seed is not None:
+        mx.random.seed(args.seed)
 
     model, tokenizer = load(
         args.model,

--- a/llms/mlx_lm/chat.py
+++ b/llms/mlx_lm/chat.py
@@ -40,7 +40,7 @@ def setup_arg_parser():
         "--seed",
         type=int,
         default=DEFAULT_SEED,
-        help="PRNG seed (default: use MLX's time-based RNG)",
+        help="PRNG seed",
     )
     parser.add_argument(
         "--max-kv-size",

--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -91,7 +91,7 @@ def setup_arg_parser():
         "--seed",
         type=int,
         default=DEFAULT_SEED,
-        help="PRNG seed (default: use MLX's time-based RNG)",
+        help="PRNG seed",
     )
     parser.add_argument(
         "--ignore-chat-template",

--- a/llms/mlx_lm/generate.py
+++ b/llms/mlx_lm/generate.py
@@ -16,7 +16,7 @@ DEFAULT_TEMP = 0.0
 DEFAULT_TOP_P = 1.0
 DEFAULT_MIN_P = 0.0
 DEFAULT_MIN_TOKENS_TO_KEEP = 1
-DEFAULT_SEED = 0
+DEFAULT_SEED = None
 DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
 DEFAULT_QUANTIZED_KV_START = 5000
 
@@ -87,7 +87,12 @@ def setup_arg_parser():
         default=DEFAULT_MIN_TOKENS_TO_KEEP,
         help="Minimum tokens to keep for min-p sampling.",
     )
-    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="PRNG seed")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_SEED,
+        help="PRNG seed (default: use MLX's time-based RNG)",
+    )
     parser.add_argument(
         "--ignore-chat-template",
         action="store_true",
@@ -160,7 +165,9 @@ def setup_arg_parser():
 def main():
     parser = setup_arg_parser()
     args = parser.parse_args()
-    mx.random.seed(args.seed)
+
+    if args.seed is not None:
+        mx.random.seed(args.seed)
 
     # Load the prompt cache and metadata if a cache file is provided
     using_cache = args.prompt_cache_file is not None


### PR DESCRIPTION
## Change DEFAULT_SEED to None for stochastic generation by default

This PR implements the suggestion from issue #1318 to change the default seed behavior for text generation.

### Changes
- Changed `DEFAULT_SEED` from `0` to `None` in both `generate.py` and `chat.py`
- Modified the main functions to only set the seed when explicitly provided
- Updated help text to clarify the new default behavior

### Rationale
As described in issue #1318:

> The mlx_lm scripts (chat.py and generate.py) currently enforce a fixed default seed of 0 for text generation, resulting in identical outputs across runs even when using stochastic sampling (e.g., --temp 1). This behavior stems from an explicit call to mx.random.seed(0) in both scripts, overriding the natural time-based RNG provided by MLX's core library in mlx.core.random.
> 
> While this ensures reproducibility, it contrasts with the typical expectation in LLM interfaces—random outputs by default unless a seed is explicitly set—and requires manual workarounds for varied outputs.

This implementation follows the suggestion by maintainer @awni:

> Why don't we just default the seed to None instead of 0? If it's not set then it takes MLXs time-based default instead of 0, which I think is pretty reasonable. One can always explicitly set the seed for reproducibility.

### Benefits
- Aligns with LLM industry standards (random outputs by default)
- Maintains backward compatibility (users can still specify `--seed 0` for old behavior)
- Uses MLX's built-in time-based RNG when no seed is provided
- Requires minimal code changes with no API changes

This change improves usability for creative and exploration use cases while maintaining the ability to get reproducible outputs when needed.
