### PR TITLE
Remove lm head if unused

### DIFF
--- a/llms/mlx_lm/models/llama.py
+++ b/llms/mlx_lm/models/llama.py
@@ -196,9 +196,12 @@ class Model(nn.Module):
 
     def sanitize(self, weights):
         # Remove unused precomputed rotary freqs
-        return {
+        weights = {
             k: v for k, v in weights.items() if "self_attn.rotary_emb.inv_freq" not in k
         }
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+        return weights
 
     @property
     def layers(self):


### PR DESCRIPTION
Remove the LM head in llama models if unused so weight validation doesn't fail.

Closes https://huggingface.co/spaces/mlx-community/mlx-my-repo/discussions/36