### PR TITLE
`make_sampler` creates sampler chain with all sampling parameters

### DIFF
--- a/llms/mlx_lm/sample_utils.py
+++ b/llms/mlx_lm/sample_utils.py
@@ -216,7 +216,7 @@ def apply_top_p(logits: mx.array, top_p: float) -> mx.array:
     original_order_probs = mx.take_along_axis(top_probs, inverse_indices, axis=-1)
 
     # Convert back to logits and return
-    return mx.log(mx.where(original_order_probs > 0, original_order_probs, 0))
+    return mx.log(original_order_probs)
 
 
 @partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)

--- a/llms/tests/test_sample_utils.py
+++ b/llms/tests/test_sample_utils.py
@@ -1,35 +1,35 @@
 import unittest
 
 import mlx.core as mx
-from mlx_lm.sample_utils import min_p_sampling, top_k_sampling, top_p_sampling
+from mlx_lm.sample_utils import apply_min_p, apply_top_k, apply_top_p
 
 
 class TestSampleUtils(unittest.TestCase):
-    def test_top_p_sampling(self):
+    def test_apply_top_p(self):
         probs = mx.array([0.9, 0.0, 0.0, 0.1])[None]
         logits = mx.log(probs)
 
-        new_logits = top_p_sampling(logits, 0.3)
+        new_logits = apply_top_p(logits, 0.3)
         actual_probs = mx.softmax(new_logits.squeeze())
         self.assertEqual(actual_probs.tolist(), [1.0, 0.0, 0.0, 0.0])
 
-        new_logits = top_p_sampling(logits, 0.95)
+        new_logits = apply_top_p(logits, 0.95)
         actual_probs = mx.softmax(new_logits.squeeze())
         self.assertEqual(probs.squeeze().tolist(), actual_probs.tolist())
 
         probs = mx.array([0.0, 0.5, 0.4, 0.1])[None]
         logits = mx.log(probs)
-        new_logits = top_p_sampling(logits, 0.4)
+        new_logits = apply_top_p(logits, 0.4)
         actual_probs = mx.softmax(new_logits.squeeze())
         self.assertEqual(actual_probs.tolist(), [0.0, 1.0, 0.0, 0.0])
 
-        new_logits = top_p_sampling(logits, 0.6)
+        new_logits = apply_top_p(logits, 0.6)
         actual_probs = mx.softmax(new_logits.squeeze())
         self.assertEqual(
             [round(p, 4) for p in actual_probs.tolist()], [0.0, 0.5556, 0.4444, 0.0]
         )
 
-        new_logits = top_p_sampling(logits, 0.95)
+        new_logits = apply_top_p(logits, 0.95)
         actual_probs = mx.softmax(new_logits.squeeze())
         actual_rounded = [round(p, 4) for p in actual_probs.tolist()]
         expected_rounded = [0.0, 0.5, 0.4, 0.1]
@@ -39,45 +39,45 @@ class TestSampleUtils(unittest.TestCase):
         # Batch mode works
         probs = mx.array([[0.9, 0.0, 0.0, 0.1], [0.0, 0.8, 0.1, 0.1]])
         logits = mx.log(probs)
-        new_logits = top_p_sampling(logits, 0.5)
+        new_logits = apply_top_p(logits, 0.5)
         actual_probs = mx.softmax(new_logits, axis=-1)
         self.assertEqual(
             actual_probs.tolist(), [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
         )
 
-    def test_min_p_sampling(self):
+    def test_apply_min_p(self):
         probs = mx.array([0.9, 0.0, 0.0, 0.1])[None]
         logits = mx.log(probs)
-        new_logits = min_p_sampling(logits, 0.8)
+        new_logits = apply_min_p(logits, 0.8)
         actual_probs = mx.softmax(new_logits.squeeze())
         self.assertEqual(actual_probs.tolist(), [1.0, 0.0, 0.0, 0.0])
 
         probs = mx.array([0.9, 0.0, 0.0, 0.1])[None]
         logits = mx.log(probs)
-        new_logits = min_p_sampling(logits, 0.05)
+        new_logits = apply_min_p(logits, 0.05)
         actual_probs = mx.softmax(new_logits.squeeze())
         self.assertEqual(actual_probs.tolist(), mx.squeeze(probs).tolist())
 
         # Batch mode works
         probs = mx.array([[0.9, 0.0, 0.0, 0.1], [0.0, 0.8, 0.0, 0.1]])
         logits = mx.log(probs)
-        new_logits = min_p_sampling(logits, 0.7)
+        new_logits = apply_min_p(logits, 0.7)
         actual_probs = mx.softmax(new_logits, axis=-1)
         self.assertEqual(
             actual_probs.tolist(), [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
         )
 
-    def test_top_k_sampling(self):
+    def test_apply_top_k(self):
         probs = mx.array([0.9, 0.0, 0.0, 0.1])[None]
         logits = mx.log(probs)
 
-        new_logits = top_k_sampling(logits, 1)
+        new_logits = apply_top_k(logits, 1)
         actual_probs = mx.softmax(new_logits.squeeze())
         self.assertEqual(actual_probs.tolist(), [1.0, 0.0, 0.0, 0.0])
 
         probs = mx.array([0.6, 0.0, 0.1, 0.3])[None]
         logits = mx.log(probs)
-        new_logits = top_k_sampling(logits, 2)
+        new_logits = apply_top_k(logits, 2)
         actual_probs = mx.softmax(new_logits.squeeze())
         self.assertEqual(
             [round(p, 4) for p in actual_probs.tolist()], [0.6667, 0.0, 0.0, 0.3333]
@@ -87,7 +87,7 @@ class TestSampleUtils(unittest.TestCase):
         probs = mx.array([[0.9, 0.0, 0.0, 0.1], [0.0, 0.8, 0.0, 0.1]])
         logits = mx.log(probs)
 
-        new_logits = top_k_sampling(logits, 1)
+        new_logits = apply_top_k(logits, 1)
         actual_probs = mx.softmax(new_logits, axis=-1)
         self.assertEqual(
             actual_probs.tolist(), [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]

--- a/llms/tests/test_sample_utils.py
+++ b/llms/tests/test_sample_utils.py
@@ -15,7 +15,7 @@ class TestSampleUtils(unittest.TestCase):
 
         new_logits = apply_top_p(logits, 0.95)
         actual_probs = mx.softmax(new_logits.squeeze())
-        self.assertEqual(probs.squeeze().tolist(), actual_probs.tolist())
+        self.assertTrue(mx.allclose(probs.squeeze(), actual_probs))
 
         probs = mx.array([0.0, 0.5, 0.4, 0.1])[None]
         logits = mx.log(probs)
@@ -56,7 +56,7 @@ class TestSampleUtils(unittest.TestCase):
         logits = mx.log(probs)
         new_logits = apply_min_p(logits, 0.05)
         actual_probs = mx.softmax(new_logits.squeeze())
-        self.assertEqual(actual_probs.tolist(), mx.squeeze(probs).tolist())
+        self.assertTrue(mx.allclose(actual_probs, mx.squeeze(probs)))
 
         # Batch mode works
         probs = mx.array([[0.9, 0.0, 0.0, 0.1], [0.0, 0.8, 0.0, 0.1]])

--- a/llms/tests/test_sample_utils.py
+++ b/llms/tests/test_sample_utils.py
@@ -8,31 +8,42 @@ class TestSampleUtils(unittest.TestCase):
     def test_top_p_sampling(self):
         probs = mx.array([0.9, 0.0, 0.0, 0.1])[None]
         logits = mx.log(probs)
-        temperature = 1.0
 
-        token = top_p_sampling(logits, 0.3, temperature).item()
-        self.assertEqual(token, 0)
+        actual_logits = top_p_sampling(logits, 0.3)
+        actual_probs = mx.softmax(actual_logits.squeeze())
+        self.assertEqual(actual_probs.tolist(), [1.0, 0.0, 0.0, 0.0])
 
-        token = top_p_sampling(logits, 0.95, temperature).item()
-        self.assertTrue(token in (0, 3))
+        actual_logits = top_p_sampling(logits, 0.95)
+        actual_probs = mx.softmax(actual_logits.squeeze())
+        self.assertEqual(probs.squeeze().tolist(), actual_probs.tolist())
 
         probs = mx.array([0.0, 0.5, 0.4, 0.1])[None]
         logits = mx.log(probs)
+        actual_logits = top_p_sampling(logits, 0.4)
+        actual_probs = mx.softmax(actual_logits.squeeze())
+        self.assertEqual(actual_probs.tolist(), [0.0, 1.0, 0.0, 0.0])
 
-        token = top_p_sampling(logits, 0.4, temperature).item()
-        self.assertEqual(token, 1)
+        actual_logits = top_p_sampling(logits, 0.6)
+        actual_probs = mx.softmax(actual_logits.squeeze())
+        self.assertEqual(
+            [round(p, 4) for p in actual_probs.tolist()], [0.0, 0.5556, 0.4444, 0.0]
+        )
 
-        token = top_p_sampling(logits, 0.6, temperature).item()
-        self.assertTrue(token in (1, 2))
-
-        token = top_p_sampling(logits, 0.95, temperature).item()
-        self.assertTrue(token in (1, 2, 3))
+        actual_logits = top_p_sampling(logits, 0.95)
+        actual_probs = mx.softmax(actual_logits.squeeze())
+        actual_rounded = [round(p, 4) for p in actual_probs.tolist()]
+        expected_rounded = [0.0, 0.5, 0.4, 0.1]
+        self.assertEqual(actual_rounded, expected_rounded)
+        self.assertAlmostEqual(sum(actual_probs.tolist()), 1.0)
 
         # Batch mode works
-        probs = mx.array([[0.9, 0.0, 0.0, 0.1], [0.0, 0.8, 0.0, 0.1]])
+        probs = mx.array([[0.9, 0.0, 0.0, 0.1], [0.0, 0.8, 0.1, 0.1]])
         logits = mx.log(probs)
-        tokens = top_p_sampling(logits, 0.5, temperature)
-        self.assertEqual(tokens.tolist(), [0, 1])
+        actual_logits = top_p_sampling(logits, 0.5)
+        actual_probs = mx.softmax(actual_logits, axis=-1)
+        self.assertEqual(
+            actual_probs.tolist(), [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
+        )
 
     def test_min_p_sampling(self):
         probs = mx.array([0.9, 0.0, 0.0, 0.1])[None]

--- a/llms/tests/test_sample_utils.py
+++ b/llms/tests/test_sample_utils.py
@@ -9,28 +9,28 @@ class TestSampleUtils(unittest.TestCase):
         probs = mx.array([0.9, 0.0, 0.0, 0.1])[None]
         logits = mx.log(probs)
 
-        actual_logits = top_p_sampling(logits, 0.3)
-        actual_probs = mx.softmax(actual_logits.squeeze())
+        new_logits = top_p_sampling(logits, 0.3)
+        actual_probs = mx.softmax(new_logits.squeeze())
         self.assertEqual(actual_probs.tolist(), [1.0, 0.0, 0.0, 0.0])
 
-        actual_logits = top_p_sampling(logits, 0.95)
-        actual_probs = mx.softmax(actual_logits.squeeze())
+        new_logits = top_p_sampling(logits, 0.95)
+        actual_probs = mx.softmax(new_logits.squeeze())
         self.assertEqual(probs.squeeze().tolist(), actual_probs.tolist())
 
         probs = mx.array([0.0, 0.5, 0.4, 0.1])[None]
         logits = mx.log(probs)
-        actual_logits = top_p_sampling(logits, 0.4)
-        actual_probs = mx.softmax(actual_logits.squeeze())
+        new_logits = top_p_sampling(logits, 0.4)
+        actual_probs = mx.softmax(new_logits.squeeze())
         self.assertEqual(actual_probs.tolist(), [0.0, 1.0, 0.0, 0.0])
 
-        actual_logits = top_p_sampling(logits, 0.6)
-        actual_probs = mx.softmax(actual_logits.squeeze())
+        new_logits = top_p_sampling(logits, 0.6)
+        actual_probs = mx.softmax(new_logits.squeeze())
         self.assertEqual(
             [round(p, 4) for p in actual_probs.tolist()], [0.0, 0.5556, 0.4444, 0.0]
         )
 
-        actual_logits = top_p_sampling(logits, 0.95)
-        actual_probs = mx.softmax(actual_logits.squeeze())
+        new_logits = top_p_sampling(logits, 0.95)
+        actual_probs = mx.softmax(new_logits.squeeze())
         actual_rounded = [round(p, 4) for p in actual_probs.tolist()]
         expected_rounded = [0.0, 0.5, 0.4, 0.1]
         self.assertEqual(actual_rounded, expected_rounded)
@@ -39,8 +39,8 @@ class TestSampleUtils(unittest.TestCase):
         # Batch mode works
         probs = mx.array([[0.9, 0.0, 0.0, 0.1], [0.0, 0.8, 0.1, 0.1]])
         logits = mx.log(probs)
-        actual_logits = top_p_sampling(logits, 0.5)
-        actual_probs = mx.softmax(actual_logits, axis=-1)
+        new_logits = top_p_sampling(logits, 0.5)
+        actual_probs = mx.softmax(new_logits, axis=-1)
         self.assertEqual(
             actual_probs.tolist(), [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
         )
@@ -48,43 +48,50 @@ class TestSampleUtils(unittest.TestCase):
     def test_min_p_sampling(self):
         probs = mx.array([0.9, 0.0, 0.0, 0.1])[None]
         logits = mx.log(probs)
-        temperature = 1.0
-        token = min_p_sampling(logits, 0.8)
-        self.assertEqual(token, 0)
+        new_logits = min_p_sampling(logits, 0.8)
+        actual_probs = mx.softmax(new_logits.squeeze())
+        self.assertEqual(actual_probs.tolist(), [1.0, 0.0, 0.0, 0.0])
 
         probs = mx.array([0.9, 0.0, 0.0, 0.1])[None]
         logits = mx.log(probs)
-        temperature = 1.0
-        for _ in range(5):
-            token = min_p_sampling(logits, 0.05)
-            self.assertTrue(token in (0, 3))
+        new_logits = min_p_sampling(logits, 0.05)
+        actual_probs = mx.softmax(new_logits.squeeze())
+        self.assertEqual(actual_probs.tolist(), mx.squeeze(probs).tolist())
 
         # Batch mode works
         probs = mx.array([[0.9, 0.0, 0.0, 0.1], [0.0, 0.8, 0.0, 0.1]])
         logits = mx.log(probs)
-        tokens = min_p_sampling(logits, 0.7)
-        self.assertEqual(tokens.tolist(), [0, 1])
+        new_logits = min_p_sampling(logits, 0.7)
+        actual_probs = mx.softmax(new_logits, axis=-1)
+        self.assertEqual(
+            actual_probs.tolist(), [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
+        )
 
     def test_top_k_sampling(self):
         probs = mx.array([0.9, 0.0, 0.0, 0.1])[None]
         logits = mx.log(probs)
 
-        token = top_k_sampling(logits, 1).item()
-        self.assertEqual(token, 0)
+        new_logits = top_k_sampling(logits, 1)
+        actual_probs = mx.softmax(new_logits.squeeze())
+        self.assertEqual(actual_probs.tolist(), [1.0, 0.0, 0.0, 0.0])
 
-        probs = mx.array([0.5, 0.0, 0.0, 0.5])[None]
-        tokens = set()
-        for _ in range(100):
-            token = top_k_sampling(logits, 2)
-            tokens.add(token.item())
-        self.assertEqual(tokens, {0, 3})
+        probs = mx.array([0.6, 0.0, 0.1, 0.3])[None]
+        logits = mx.log(probs)
+        new_logits = top_k_sampling(logits, 2)
+        actual_probs = mx.softmax(new_logits.squeeze())
+        self.assertEqual(
+            [round(p, 4) for p in actual_probs.tolist()], [0.6667, 0.0, 0.0, 0.3333]
+        )
 
         # Batch mode works
         probs = mx.array([[0.9, 0.0, 0.0, 0.1], [0.0, 0.8, 0.0, 0.1]])
         logits = mx.log(probs)
 
-        tokens = top_k_sampling(logits, 1)
-        self.assertEqual(tokens.tolist(), [0, 1])
+        new_logits = top_k_sampling(logits, 1)
+        actual_probs = mx.softmax(new_logits, axis=-1)
+        self.assertEqual(
+            actual_probs.tolist(), [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1219 

Apply samplers in this order: top-k --> top-p --> min-p --> temp

The sampler methods were refactored to return the transformed logits instead of a token. Now, we can can chain them together to apply a series of sampling methods.

The method names of the samplers were changed to indicate that the implementation has changed, i.e., each method returns logits instead of a token. I am not sure about the API stability requirements, so let me know if you have a preference on the method name.

The temperature adjustment was removed from each sampler application, and instead it's applied only once as the very last step.