### PR TITLE
Adding reporting to wandb

### DIFF
--- a/llms/mlx_lm/tuner/trainer.py
+++ b/llms/mlx_lm/tuner/trainer.py
@@ -1,20 +1,14 @@
 # Copyright © 2024 Apple Inc.
 
-import glob
-import shutil
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 from mlx.nn.utils import average_gradients
 from mlx.utils import tree_flatten
-from transformers import PreTrainedTokenizer
-
-from .datasets import CompletionsDataset
 
 
 def grad_checkpoint(layer):


### PR DESCRIPTION
with `--report-to-wandb` as a flag:


output:

```text
wandb: Using wandb-core as the SDK backend.  Please refer to https://wandb.me/wandb-core for more information.
wandb: Currently logged in as:------ to https://api.wandb.ai. Use `wandb login --relogin` to force relogin
wandb: Tracking run with wandb version 0.19.8
wandb: Run data is saved locally in /Users/gokdenizgulmez/Desktop/mlx-examples/llms/wandb/run-20250312_142859-i31zyslt
wandb: Run `wandb offline` to turn off syncing.
wandb: Syncing run frosty-shape-3
wandb: ⭐️ View project at https://wandb.ai/----/mlx-finetuning
wandb: 🚀 View run at https://wandb.ai/-----/mlx-finetuning/runs/i31zyslt
...
wandb: 
wandb: 🚀 View run happy-disco-4 at: https://wandb.ai/-----/mlx-finetuning/runs/m9qlbet4
wandb: Find logs at: wandb/run-20250312_143803-m9qlbet4/logs
```


<img width="1518" alt="Bildschirmfoto 2025-03-12 um 14 40 49" src="https://github.com/user-attachments/assets/38f1bb9c-07a0-4a1f-b3ff-005bdf35148d" />

