### PR TITLE
Make sure to use UTF-8 when loading tokenizer.json

### DIFF
--- a/llms/mlx_lm/tokenizer_utils.py
+++ b/llms/mlx_lm/tokenizer_utils.py
@@ -352,7 +352,7 @@ def load_tokenizer(model_path, tokenizer_config_extra={}, eos_token_ids=None):
 
     tokenizer_file = model_path / "tokenizer.json"
     if tokenizer_file.exists():
-        with open(tokenizer_file, "r") as fid:
+        with open(tokenizer_file, "r", encoding="utf-8") as fid:
             tokenizer_content = json.load(fid)
         if "decoder" in tokenizer_content:
             if _is_spm_decoder(tokenizer_content["decoder"]):


### PR DESCRIPTION
Explicitly set the `encoding` to UTF-8 when loading `tokenizers.json`, because as the documentation for [open()](https://docs.python.org/3/library/functions.html#open) says

> if encoding is not specified the encoding used is platform-dependent

which resulted in the following error when running in an (admittedly unusual) environment with no locale set

```
Python exception: 'ascii' codec can't decode byte 0xc2 in position 6725: ordinal not in range(128)
Traceback:
  File "test.py", line 36, in load_model
    model, tokenizer = mlx_lm.load(name)
                       ~~~~~~~~~~~^^^^^^
  File "venv/lib/python3.13/site-packages/mlx_lm/utils.py", line 788, in load
    tokenizer = load_tokenizer(
        model_path, tokenizer_config, eos_token_ids=config.get("eos_token_id", None)
    )
  File "venv/lib/python3.13/site-packages/mlx_lm/tokenizer_utils.py", line 356, in load_tokenizer
    tokenizer_content = json.load(fid)
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/json/__init__.py", line 293, in load
    return loads(fp.read(),
                 ~~~~~~~^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
```