### PR TITLE
LoRa/README.md should be --hf-path instead of --hf-repo

### DIFF
--- a/lora/README.md
+++ b/lora/README.md
@@ -166,7 +166,7 @@ useful for the sake of attribution and model versioning.
 For example, to fuse and upload a model derived from Mistral-7B-v0.1, run: 
 
 ```
-python fuse.py --upload-name My-4-bit-model --hf-repo mistralai/Mistral-7B-v0.1
+python fuse.py --upload-name My-4-bit-model --hf-path mistralai/Mistral-7B-v0.1
 ```
 
 ## Custom Data


### PR DESCRIPTION
--hf-repo is not part of `fuse.py` arguments