### PR TITLE
Use `model.safetensors` with Whisper

### DIFF
--- a/whisper/convert.py
+++ b/whisper/convert.py
@@ -382,7 +382,7 @@ if __name__ == "__main__":
 
     # Save weights
     print("[INFO] Saving")
-    mx.save_safetensors(str(mlx_path / "weights.safetensors"), weights)
+    mx.save_safetensors(str(mlx_path / "model.safetensors"), weights)
 
     # Save config.json with model_type
     with open(str(mlx_path / "config.json"), "w") as f:

--- a/whisper/mlx_whisper/load_models.py
+++ b/whisper/mlx_whisper/load_models.py
@@ -26,7 +26,10 @@ def load_model(
 
     model_args = whisper.ModelDimensions(**config)
 
-    wf = model_path / "weights.safetensors"
+    # Prefer model.safetensors, fall back to weights.safetensors, then weights.npz
+    wf = model_path / "model.safetensors"
+    if not wf.exists():
+        wf = model_path / "weights.safetensors"
     if not wf.exists():
         wf = model_path / "weights.npz"
     weights = mx.load(str(wf))


### PR DESCRIPTION
I've created new Whisper repos on Hugging Face with the weights stored in `model.safetensors` files for use with my Swift port of Whisper in [mlx-swift-audio](https://github.com/DePasqualeOrg/mlx-swift-audio). Many of the Whisper models in the MLX Community include the weights in .npz format, which Swift apps can't read. OpenAI's Whisper repos on Hugging Face use `model.safetensors`.

I've updated the model loading logic to look for `model.safetensors` first and fall back to `weights.safetensors` and `weights.npz`. The conversion script now saves the weights as `model.safetensors`.