### PR TITLE
perf(whisper): lazy-import timing module to avoid loading scipy/numba

### DIFF
--- a/whisper/mlx_whisper/transcribe.py
+++ b/whisper/mlx_whisper/transcribe.py
@@ -19,7 +19,6 @@ from .audio import (
 )
 from .decoding import DecodingOptions, DecodingResult
 from .load_models import load_model
-from .timing import add_word_timestamps
 from .tokenizer import LANGUAGES, get_tokenizer
 
 
@@ -412,6 +411,8 @@ def transcribe(
                     seek += segment_size
 
                 if word_timestamps:
+                    from .timing import add_word_timestamps
+
                     add_word_timestamps(
                         segments=current_segments,
                         model=model,


### PR DESCRIPTION
## Summary

- Move `from .timing import add_word_timestamps` from module-level to inside the `if word_timestamps:` guard in `transcribe()`
- Makes `scipy` and `numba` truly optional when `word_timestamps=False` (the default)

## Problem

`timing.py` imports `scipy` and `numba` at module level:

```python
import numba           # timing.py:8
from scipy import signal  # timing.py:10
```

These are loaded unconditionally via `transcribe.py`'s top-level `from .timing import add_word_timestamps`, even when `word_timestamps=False`. This eagerly loads ~620 Python modules and ~212 MB of native libraries that are never used.

## Fix

One-line change: move the import inside the `if word_timestamps:` conditional where it's actually needed.

```diff
- from .timing import add_word_timestamps

  if word_timestamps:
+     from .timing import add_word_timestamps
+
      add_word_timestamps(...)
```

## Impact

- **Import time**: `import mlx_whisper` no longer loads scipy/numba/llvmlite
- **Packaging**: Downstream apps using PyInstaller/cx_Freeze can exclude scipy (~71 MB), numba (~31 MB), and llvmlite (~110 MB) from bundles when word timestamps aren't needed
- **Zero behavior change**: When `word_timestamps=True`, the import fires on first use and everything works identically

## Testing

- `word_timestamps=False` (default): scipy/numba never imported — verified via `sys.modules` inspection
- `word_timestamps=True`: import fires inside the conditional, all word timestamp functionality works as before