### PR TITLE
headers 1,3,4 -> headers 1,2,3

### DIFF
--- a/whisper/README.md
+++ b/whisper/README.md
@@ -4,7 +4,7 @@ Speech recognition with Whisper in MLX. Whisper is a set of open source speech
 recognition models from OpenAI, ranging from 39 million to 1.5 billion
 parameters.[^1]
 
-### Setup
+## Setup
 
 Install [`ffmpeg`](https://ffmpeg.org/):
 
@@ -19,9 +19,9 @@ Install the `mlx-whisper` package with:
 pip install mlx-whisper
 ```
 
-### Run
+## Run
 
-#### CLI
+### CLI
 
 At its simplest:
 
@@ -44,7 +44,7 @@ some-process | mlx_whisper -
 The default output file name will be `content.*`. You can specify the name with
 the `--output-name` flag.
 
-#### API
+### API
 
 Transcribe audio with:
 
@@ -82,7 +82,7 @@ To see more transcription options use:
 >>> help(mlx_whisper.transcribe)
 ```
 
-### Converting models
+## Converting models
 
 > [!TIP]
 > Skip the conversion step by using pre-converted checkpoints from the Hugging


### PR DESCRIPTION
This replaces the header structure using `#` (for the title) and then `###` + `####` with `##` + `###`.

This is in line with the README.md files from the other folders, it also makes it easier to read (the difference between h3 and h4 is hard to spot).