### PR TITLE
Consistency with all whisper transcription segments having word-level data, and yet add defensive coding

### DIFF
--- a/whisper/mlx_whisper/transcribe.py
+++ b/whisper/mlx_whisper/transcribe.py
@@ -41,10 +41,11 @@ def _format_timestamp(seconds: float):
 
 
 def _get_end(segments: List[dict]) -> Optional[float]:
-    return next(
-        (w["end"] for s in reversed(segments) for w in reversed(s["words"])),
-        segments[-1]["end"] if segments else None,
-    )
+    for s in reversed(segments):
+        words = s.get("words") or []
+        if words:
+            return words[-1]["end"]
+    return segments[-1]["end"] if segments else None
 
 
 class ModelHolder:

--- a/whisper/mlx_whisper/writers.py
+++ b/whisper/mlx_whisper/writers.py
@@ -27,11 +27,16 @@ def format_timestamp(
     )
 
 
+def _segments_use_word_timings(segments: List[dict]) -> bool:
+    return bool(segments) and all(s.get("words") for s in segments)
+
+
 def get_start(segments: List[dict]) -> Optional[float]:
-    return next(
-        (w["start"] for s in segments for w in s["words"]),
-        segments[0]["start"] if segments else None,
-    )
+    for s in segments:
+        words = s.get("words") or []
+        if words:
+            return words[0]["start"]
+    return segments[0]["start"] if segments else None
 
 
 class ResultWriter:
@@ -143,7 +148,7 @@ class SubtitlesWriter(ResultWriter):
             if len(subtitle) > 0:
                 yield subtitle
 
-        if len(result["segments"]) > 0 and "words" in result["segments"][0]:
+        if _segments_use_word_timings(result["segments"]):
             for subtitle in iterate_subtitles():
                 subtitle_start = self.format_timestamp(subtitle[0]["start"])
                 subtitle_end = self.format_timestamp(subtitle[-1]["end"])

--- a/whisper/test.py
+++ b/whisper/test.py
@@ -1,5 +1,6 @@
 # Copyright © 2023-2024 Apple Inc.
 
+import importlib
 import json
 import os
 import unittest
@@ -11,6 +12,7 @@ import mlx_whisper
 import mlx_whisper.audio as audio
 import mlx_whisper.decoding as decoding
 import mlx_whisper.load_models as load_models
+import mlx_whisper.writers as writers
 import numpy as np
 import torch
 from convert import convert, load_torch_model, quantize
@@ -438,6 +440,146 @@ class TestWhisper(unittest.TestCase):
 
         # Randomly check a couple of segments
         check_words(result["segments"][0]["words"], expected_0)
+
+
+class TestSegmentWordTimings(unittest.TestCase):
+    """Guards segment vs. word-level timing helpers (mixed / missing word lists)."""
+
+    def test_segments_use_word_timings(self):
+        self.assertFalse(writers._segments_use_word_timings([]))
+        self.assertFalse(
+            writers._segments_use_word_timings(
+                [
+                    {
+                        "start": 0.0,
+                        "end": 1.0,
+                        "text": "a",
+                        "words": [{"word": "a", "start": 0.0, "end": 1.0}],
+                    },
+                    {"start": 2.0, "end": 3.0, "text": "b"},
+                ]
+            )
+        )
+        self.assertFalse(
+            writers._segments_use_word_timings(
+                [
+                    {
+                        "start": 0.0,
+                        "end": 1.0,
+                        "text": "a",
+                        "words": [{"word": "a", "start": 0.0, "end": 1.0}],
+                    },
+                    {"start": 2.0, "end": 3.0, "text": "b", "words": []},
+                ]
+            )
+        )
+        self.assertTrue(
+            writers._segments_use_word_timings(
+                [
+                    {
+                        "start": 0.0,
+                        "end": 1.0,
+                        "text": "a",
+                        "words": [{"word": "a", "start": 0.0, "end": 1.0}],
+                    },
+                    {
+                        "start": 2.0,
+                        "end": 3.0,
+                        "text": "b",
+                        "words": [{"word": "b", "start": 2.0, "end": 3.0}],
+                    },
+                ]
+            )
+        )
+
+    def test_get_start(self):
+        self.assertIsNone(writers.get_start([]))
+        self.assertEqual(
+            writers.get_start(
+                [{"start": 5.0, "end": 10.0, "text": "no words key"}]
+            ),
+            5.0,
+        )
+        self.assertEqual(
+            writers.get_start(
+                [
+                    {"start": 0.0, "end": 1.0, "text": "a"},
+                    {
+                        "start": 2.0,
+                        "end": 4.0,
+                        "text": "b",
+                        "words": [{"word": "b", "start": 2.5, "end": 4.0}],
+                    },
+                ]
+            ),
+            2.5,
+        )
+
+    def test_get_end(self):
+        transcribe_mod = importlib.import_module("mlx_whisper.transcribe")
+        self.assertIsNone(transcribe_mod._get_end([]))
+        # Last segment has no words: use the last segment-from-end that still has words.
+        self.assertEqual(
+            transcribe_mod._get_end(
+                [
+                    {
+                        "start": 0.0,
+                        "end": 5.0,
+                        "text": "a",
+                        "words": [{"word": "a", "start": 0.0, "end": 5.0}],
+                    },
+                    {"start": 10.0, "end": 20.0, "text": "b"},
+                ]
+            ),
+            5.0,
+        )
+        # No non-empty word lists: fall back to the final segment boundary.
+        self.assertEqual(
+            transcribe_mod._get_end(
+                [
+                    {"start": 0.0, "end": 3.0, "text": "a"},
+                    {"start": 10.0, "end": 20.0, "text": "b"},
+                ]
+            ),
+            20.0,
+        )
+        self.assertEqual(
+            transcribe_mod._get_end(
+                [
+                    {
+                        "start": 0.0,
+                        "end": 3.0,
+                        "text": "a",
+                        "words": [{"word": "a", "start": 0.0, "end": 3.0}],
+                    },
+                    {
+                        "start": 4.0,
+                        "end": 7.0,
+                        "text": "b",
+                        "words": [{"word": "b", "start": 4.0, "end": 7.0}],
+                    },
+                ]
+            ),
+            7.0,
+        )
+
+    def test_write_srt_mixed_word_and_segment_timings(self):
+        """Regression: first segment must not force word-level path for all segments."""
+        result = {
+            "segments": [
+                {
+                    "start": 0.0,
+                    "end": 1.0,
+                    "text": " Hello",
+                    "words": [{"word": " Hello", "start": 0.0, "end": 1.0}],
+                },
+                {"start": 2.0, "end": 5.0, "text": " world"},
+            ]
+        }
+        writer = writers.WriteSRT("/tmp")
+        lines = list(writer.iterate_result(result))
+        self.assertEqual(len(lines), 2)
+        self.assertTrue(all(len(t) == 3 for t in lines))
 
 
 class TestAudio(unittest.TestCase):


### PR DESCRIPTION
Fix for Whisper subtitle generation which was entering word-level mode after checking only `segments[0]` for `"words"`, but sometimes that key is missing in later segments e.g. with `--task translate`, and this was killing `get_start()` with a KeyError.

Also added a basic test class

```sh
PYTHONPATH=whisper python -m unittest test.TestSegmentWordTimings -v
```

Closes #1418