### PR TITLE
fix(t5): use prefix-redecode for streaming so byte-level BPE tokenizers work

### DIFF
--- a/t5/t5.py
+++ b/t5/t5.py
@@ -37,9 +37,26 @@ class Tokenizer:
             )["input_ids"]
         )
 
-    def decode(self, t: List[int], with_sep: bool = True) -> str:
-        tokens = self._tokenizer.convert_ids_to_tokens(t)
-        return "".join(t.replace("▁", " " if with_sep else "") for t in tokens)
+    def decode(self, t: List[int]) -> str:
+        return self._tokenizer.decode(t, skip_special_tokens=True)
+
+    def new_stream_state(self) -> dict:
+        """Return state for incremental streaming detokenization.
+
+        Per-token detokenization is unsafe for most HuggingFace tokenizers
+        (byte-level BPE merges and SentencePiece byte-fallback both span
+        multiple ids), so the streaming loop must hand each new id to
+        ``stream_decode`` along with this state object.
+        """
+        return {"ids": [], "text": ""}
+
+    def stream_decode(self, state: dict, token_id: int) -> str:
+        """Append ``token_id`` to ``state`` and return the new text fragment."""
+        state["ids"].append(int(token_id))
+        text = self._tokenizer.decode(state["ids"], skip_special_tokens=True)
+        delta = text[len(state["text"]) :]
+        state["text"] = text
+        return delta
 
 
 def _relative_position_bucket(
@@ -505,13 +522,14 @@ if __name__ == "__main__":
     print("Input: ", args.prompt, flush=True)
 
     start = perf_counter_ns()
+    stream_state = tokenizer.new_stream_state()
     for token, n_tokens in zip(
         generate(args.prompt, model, tokenizer, args.temp), range(args.max_tokens)
     ):
         if token.item() == tokenizer.eos_id:
             break
         print(
-            tokenizer.decode([token.item()], with_sep=n_tokens > 0),
+            tokenizer.stream_decode(stream_state, token.item()),
             end="",
             flush=True,
         )

--- a/t5/test_tokenizer_stream.py
+++ b/t5/test_tokenizer_stream.py
@@ -1,0 +1,63 @@
+"""Tests for streaming detokenization in t5.py.
+
+Reproduces and guards against the bug reported in
+https://github.com/ml-explore/mlx-examples/issues/1021 where streaming
+generation emitted raw subword markers (e.g. ``Ġ``/``Ċ`` for the byte-level
+BPE tokenizer used by ``Salesforce/codet5p-220m``) instead of plain text.
+
+The previous implementation called ``convert_ids_to_tokens`` per generated
+token and only stripped the SentencePiece ``▁`` marker, which is wrong for
+byte-level BPE tokenizers and for SentencePiece tokens that use byte-fallback.
+The fix decodes the running prefix with the HuggingFace tokenizer's own
+``decode`` and yields the new substring on each step.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from t5 import Tokenizer
+
+
+def _make_tokenizer(model_name: str, decoder_start_id: int = 0) -> Tokenizer:
+    config = SimpleNamespace(decoder_start_token_id=decoder_start_id)
+    return Tokenizer(config, model_name)
+
+
+def _stream_decode(tokenizer: Tokenizer, ids):
+    """Mimic the streaming loop in ``t5.py``'s ``__main__``."""
+    out = []
+    state = tokenizer.new_stream_state()
+    for tid in ids:
+        out.append(tokenizer.stream_decode(state, int(tid)))
+    return "".join(out)
+
+
+@pytest.mark.parametrize(
+    "model_name,prompt",
+    [
+        ("t5-small", "translate English to German: That is good."),
+        ("Salesforce/codet5p-220m", "def print_hello_world():"),
+    ],
+)
+def test_stream_decode_matches_full_decode(model_name: str, prompt: str) -> None:
+    tokenizer = _make_tokenizer(model_name)
+    ids = tokenizer._tokenizer(prompt, return_tensors="np")["input_ids"][0].tolist()
+
+    expected = tokenizer._tokenizer.decode(ids, skip_special_tokens=True)
+    streamed = _stream_decode(tokenizer, ids)
+
+    assert streamed == expected
+
+
+def test_stream_decode_strips_byte_level_bpe_markers() -> None:
+    """Regression: ``Ġ`` / ``Ċ`` must never leak into streamed output."""
+    tokenizer = _make_tokenizer("Salesforce/codet5p-220m")
+    ids = tokenizer._tokenizer('def hello():\n    print("hi")', return_tensors="np")[
+        "input_ids"
+    ][0].tolist()
+
+    streamed = _stream_decode(tokenizer, ids)
+
+    assert "Ġ" not in streamed
+    assert "Ċ" not in streamed


### PR DESCRIPTION
## Summary

Fixes #1021. `t5/t5.py` `Tokenizer.decode` called `self._tokenizer.convert_ids_to_tokens(t)` per token and only stripped SentencePiece `▁`. The `__main__` streaming loop fed it one token id at a time. For tokenizers whose ids don't map 1:1 to characters this is broken:

- Byte-level BPE (`RobertaTokenizerFast` used by `Salesforce/codet5p-220m`) emits raw GPT-2 byte markers `Ġ` (space) and `Ċ` (newline) which the `▁` replacement never touches.
- SentencePiece byte-fallback emits hex byte tokens that also need decoding.

## Fix

Replace per-token `convert_ids_to_tokens` with a small streaming-state API that delegates to the HuggingFace tokenizer's own `decode(prefix, skip_special_tokens=True)` and yields the new substring each step — exactly the "redecode the entire prefix" path @awni suggested in the issue thread.

```
def new_stream_state(self) -> dict: ...
def stream_decode(self, state, token_id) -> str: ...
def decode(self, t) -> str:  # batch decode now also via HF
    return self._tokenizer.decode(t, skip_special_tokens=True)
```

`__main__` updated to call `stream_decode(state, token.item())` instead of `decode([token.item()], with_sep=...)`. `with_sep` flag removed (only ever set in this one call site — checked via grep across the repo). +22/-4 production.

## Test

`t5/test_tokenizer_stream.py` — parametrized: `t5-small` (SentencePiece) + `Salesforce/codet5p-220m` (byte-level BPE). Asserts streamed output equals full-prefix `decode(ids, skip_special_tokens=True)`. Regression: asserts no `Ġ` / `Ċ` ever appear in streamed output for codet5p code generation.

TDD RED first (`AttributeError: 'Tokenizer' object has no attribute 'new_stream_state'`), then GREEN (3/3 pass). End-to-end repro encoded the exact buggy snippet from the issue (`'\n    print("Hello World")\n\n'`), streamed via the new API, output matches expected with no markers leaked.

`black` + `isort --profile=black` clean.

## Risk notes

- `Tokenizer.decode(list_of_ids)` no longer accepts `with_sep` kwarg. Only call site rewritten.
- Quadratic cost in output length per stream — acceptable for typical T5 lengths and explicitly accepted by the maintainer in the issue thread; alternative would be a proper incremental detokenizer (much larger change).

Refs #1021