### PR TITLE
Add LLaVA LoRA fine-tuning example

### DIFF
--- a/llava/README.md
+++ b/llava/README.md
@@ -47,14 +47,56 @@ max_tokens, temperature = 128, 0.0
 
 prompt = "USER: <image>\nWhat are these?\nASSISTANT:"
 image = "http://images.cocodataset.org/val2017/000000039769.jpg"
-input_ids, pixel_values = prepare_inputs(processor, image, prompt)
+pixel_values, input_ids, image_sizes = prepare_inputs(processor, image, prompt)
 
 reply = generate_text(
-    input_ids, pixel_values, model, processor, max_tokens, temperature
+    input_ids,
+    pixel_values,
+    model,
+    processor,
+    max_tokens,
+    temperature,
+    image_sizes=image_sizes,
 )
 
 print(reply)
 ```
+
+For LLaVA 1.6 models, use the matching prompt format and model name:
+
+```bash
+python generate.py \
+  --model llava-hf/llava-v1.6-mistral-7b-hf \
+  --image "http://images.cocodataset.org/val2017/000000039769.jpg" \
+  --prompt "[INST] <image>\nWhat are these? [/INST]" \
+  --max-tokens 128 \
+  --temp 0
+```
+
+## LoRA Fine-tuning
+
+The `train_lora.py` script fine-tunes LoRA adapters on the language model while
+keeping the vision tower and multimodal projector frozen. It expects JSONL
+records with an image, prompt, and response:
+
+```json
+{"image": "path/to/image.jpg", "prompt": "[INST] <image>\nDescribe this image. [/INST]", "text": "A short description of the image."}
+```
+
+Run fine-tuning with:
+
+```bash
+python train_lora.py \
+  --model llava-hf/llava-v1.6-mistral-7b-hf \
+  --train-data train.jsonl \
+  --valid-data valid.jsonl \
+  --iters 600 \
+  --adapter-file llava_adapters.npz
+```
+
+Only response tokens from `text` contribute to the loss. The prompt and image
+tokens are included as context but masked from the loss. Fine-tuning currently
+uses a batch size of 1.
 
 [^1]:
     Refer to [LLaVA project webpage](https://llava-vl.github.io/) for more

--- a/llava/generate.py
+++ b/llava/generate.py
@@ -79,14 +79,19 @@ def load_image(image_source):
 def prepare_inputs(processor, image, prompt):
     if isinstance(image, str):
         image = load_image(image)
-    inputs = processor(image, prompt, return_tensors="np")
+    inputs = processor(images=image, text=prompt, return_tensors="np")
     pixel_values = mx.array(inputs["pixel_values"])
     input_ids = mx.array(inputs["input_ids"])
-    return pixel_values, input_ids
+    image_sizes = inputs.get("image_sizes")
+    if image_sizes is not None:
+        image_sizes = mx.array(image_sizes)
+    return pixel_values, input_ids, image_sizes
 
 
 def load_model(model_path, tokenizer_config={}):
-    processor = AutoProcessor.from_pretrained(model_path, **tokenizer_config)
+    processor = AutoProcessor.from_pretrained(
+        model_path, use_fast=False, **tokenizer_config
+    )
     model = LlavaModel.from_pretrained(model_path)
     return processor, model
 
@@ -98,8 +103,10 @@ def sample(logits, temperature=0.0):
         return mx.random.categorical(logits * (1 / temperature))
 
 
-def generate_text(input_ids, pixel_values, model, processor, max_tokens, temperature):
-    logits, cache = model(input_ids, pixel_values)
+def generate_text(
+    input_ids, pixel_values, model, processor, max_tokens, temperature, image_sizes=None
+):
+    logits, cache = model(input_ids, pixel_values, image_sizes=image_sizes)
     logits = logits[:, -1, :]
     y = sample(logits, temperature=temperature)
     tokens = [y.item()]
@@ -126,11 +133,17 @@ def main():
     processor, model = load_model(args.model, tokenizer_config)
 
     prompt = codecs.decode(args.prompt, "unicode_escape")
-    pixel_values, input_ids = prepare_inputs(processor, args.image, prompt)
+    pixel_values, input_ids, image_sizes = prepare_inputs(processor, args.image, prompt)
 
     print(prompt)
     generated_text = generate_text(
-        input_ids, pixel_values, model, processor, args.max_tokens, args.temp
+        input_ids,
+        pixel_values,
+        model,
+        processor,
+        args.max_tokens,
+        args.temp,
+        image_sizes=image_sizes,
     )
     print(generated_text)
 

--- a/llava/language.py
+++ b/llava/language.py
@@ -21,6 +21,7 @@ class TextConfig:
     rope_theta: float = 10000
     rope_traditional: bool = False
     rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    rope_parameters: Optional[Dict[str, Union[float, str]]] = None
 
     @classmethod
     def from_dict(cls, params):
@@ -35,6 +36,9 @@ class TextConfig:
     def __post_init__(self):
         if self.num_key_value_heads is None:
             self.num_key_value_heads = self.num_attention_heads
+
+        if self.rope_parameters is not None:
+            self.rope_theta = self.rope_parameters.get("rope_theta", self.rope_theta)
 
         if self.rope_scaling:
             required_keys = {"factor", "type"}
@@ -188,9 +192,10 @@ class LanguageModel(nn.Module):
     def __init__(self, config: TextConfig):
         super().__init__()
         self.model_type = config.model_type
-        if self.model_type != "llama":
+        if self.model_type not in ["llama", "mistral"]:
             raise ValueError(
-                f"Model type {self.model_type} not supported. Currently only 'llama' is supported"
+                f"Model type {self.model_type} not supported. Currently only "
+                "'llama' and 'mistral' are supported"
             )
         self.model = Llama(config)
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)

--- a/llava/llava.py
+++ b/llava/llava.py
@@ -21,8 +21,11 @@ class LlaVAConfig:
     vision_config: VisionConfig
     ignore_index: int = -100
     image_token_index: int = 32000
+    image_grid_pinpoints: Optional[list] = None
+    image_seq_length: int = 576
     vision_feature_select_strategy: str = "default"
     vision_feature_layer: int = -2
+    use_image_newline_parameter: bool = False
     vocab_size: int = 32000
 
     @classmethod
@@ -62,37 +65,43 @@ class LlavaModel(nn.Module):
         self.multi_modal_projector = LlavaMultiModalProjector(config)
         self.vision_feature_layer = config.vision_feature_layer
         self.vision_feature_select_strategy = config.vision_feature_select_strategy
+        if config.use_image_newline_parameter:
+            self.image_newline = mx.zeros(config.text_config.hidden_size)
 
     def get_input_embeddings(
         self,
         input_ids: Optional[mx.array] = None,
         pixel_values: Optional[mx.array] = None,
+        image_sizes: Optional[mx.array] = None,
     ):
         # Get the input embeddings from the language model
         inputs_embeds = self.language_model.model.embed_tokens(input_ids)
         if pixel_values is None:
             return inputs_embeds
 
-        # Get the ouptut hidden states from the vision model
-        *_, hidden_states = self.vision_tower(
-            pixel_values.transpose(0, 2, 3, 1), output_hidden_states=True
-        )
-
-        # Select the hidden states from the desired layer
-        selected_image_feature = hidden_states[self.vision_feature_layer]
-
-        if self.vision_feature_select_strategy == "default":
-            selected_image_feature = selected_image_feature[:, 1:]
-        elif self.vision_feature_select_strategy == "full":
-            selected_image_feature = selected_image_feature
+        if pixel_values.ndim == 5:
+            image_features = self.get_image_features(pixel_values, image_sizes)
         else:
-            raise ValueError(
-                "Unexpected feature selection strategy: "
-                f"{self.vision_feature_select_strategy}"
+            # Get the output hidden states from the vision model
+            *_, hidden_states = self.vision_tower(
+                pixel_values.transpose(0, 2, 3, 1), output_hidden_states=True
             )
 
-        # Pass image features through the multi-modal projector
-        image_features = self.multi_modal_projector(selected_image_feature)
+            # Select the hidden states from the desired layer
+            selected_image_feature = hidden_states[self.vision_feature_layer]
+
+            if self.vision_feature_select_strategy == "default":
+                selected_image_feature = selected_image_feature[:, 1:]
+            elif self.vision_feature_select_strategy == "full":
+                selected_image_feature = selected_image_feature
+            else:
+                raise ValueError(
+                    "Unexpected feature selection strategy: "
+                    f"{self.vision_feature_select_strategy}"
+                )
+
+            # Pass image features through the multi-modal projector
+            image_features = self.multi_modal_projector(selected_image_feature)
 
         # Insert special image tokens in the input_ids
         final_inputs_embeds = self._merge_input_ids_with_image_features(
@@ -100,11 +109,117 @@ class LlavaModel(nn.Module):
         )
         return final_inputs_embeds
 
+    def get_image_features(self, pixel_values: mx.array, image_sizes: mx.array):
+        if image_sizes is None:
+            raise ValueError("image_sizes must be provided for LLaVA-NeXT images.")
+
+        if hasattr(image_sizes, "tolist"):
+            image_sizes = image_sizes.tolist()
+        image_sizes = np.array(image_sizes)
+        image_num_patches = [
+            image_size_to_num_patches(
+                image_size=image_size,
+                grid_pinpoints=self.config.image_grid_pinpoints,
+                patch_size=self.config.vision_config.image_size,
+            )
+            for image_size in image_sizes
+        ]
+
+        pixel_values = [
+            pixel_value[:num_patches]
+            for pixel_value, num_patches in zip(pixel_values, image_num_patches)
+        ]
+        pixel_values = mx.concatenate(pixel_values, axis=0)
+
+        *_, hidden_states = self.vision_tower(
+            pixel_values.transpose(0, 2, 3, 1), output_hidden_states=True
+        )
+        selected_image_feature = hidden_states[self.vision_feature_layer]
+
+        if self.vision_feature_select_strategy == "default":
+            selected_image_feature = selected_image_feature[:, 1:]
+        elif self.vision_feature_select_strategy != "full":
+            raise ValueError(
+                "Unexpected feature selection strategy: "
+                f"{self.vision_feature_select_strategy}"
+            )
+
+        image_features = self.multi_modal_projector(selected_image_feature)
+        split_image_features = []
+        start = 0
+        for num_patches in image_num_patches:
+            split_image_features.append(image_features[start : start + num_patches])
+            start += num_patches
+        image_features = split_image_features
+        image_features = self.pack_image_features(image_features, image_sizes)
+        return mx.concatenate(image_features, axis=0)[None]
+
+    def pack_image_features(self, image_features, image_sizes):
+        new_image_features = []
+        image_newline = getattr(self, "image_newline", None)
+
+        for image_feature, image_size in zip(image_features, image_sizes):
+            if image_feature.shape[0] > 1:
+                base_image_feature = image_feature[0]
+                image_feature = image_feature[1:]
+                height = width = (
+                    self.config.vision_config.image_size
+                    // self.config.vision_config.patch_size
+                )
+                num_patch_height, num_patch_width = get_anyres_image_grid_shape(
+                    image_size,
+                    self.config.image_grid_pinpoints,
+                    self.config.vision_config.image_size,
+                )
+                image_feature = image_feature.reshape(
+                    num_patch_height, num_patch_width, height, width, -1
+                )
+                image_feature = image_feature.transpose(4, 0, 2, 1, 3)
+                image_feature = image_feature.reshape(
+                    image_feature.shape[0],
+                    num_patch_height * height,
+                    num_patch_width * width,
+                )
+                image_feature = unpad_image(image_feature, image_size)
+
+                if image_newline is not None:
+                    newline = mx.broadcast_to(
+                        image_newline[:, None, None],
+                        (*image_feature.shape[:-1], 1),
+                    )
+                    image_feature = mx.concatenate(
+                        (image_feature, newline.astype(image_feature.dtype)),
+                        axis=-1,
+                    )
+
+                image_feature = image_feature.reshape(
+                    image_feature.shape[0],
+                    image_feature.shape[1] * image_feature.shape[2],
+                ).T
+                image_feature = mx.concatenate(
+                    (base_image_feature, image_feature), axis=0
+                )
+            else:
+                image_feature = image_feature[0]
+                if image_newline is not None:
+                    image_feature = mx.concatenate(
+                        (
+                            image_feature,
+                            image_newline[None].astype(image_feature.dtype),
+                        ),
+                        axis=0,
+                    )
+            new_image_features.append(image_feature)
+
+        return new_image_features
+
     def _merge_input_ids_with_image_features(
         self, image_features, inputs_embeds, input_ids
     ):
         image_token_index = self.config.image_token_index
-        batch_size, num_image_patches, embed_dim = image_features.shape
+        if image_features.ndim == 3:
+            image_features = image_features[0]
+        num_image_patches = image_features.shape[0]
 
         # Positions of <image> tokens in input_ids, assuming batch size is 1
         image_positions = mx.array(
@@ -120,8 +235,16 @@ class LlavaModel(nn.Module):
         inputs_embeds[0, image_positions] = image_features
         return inputs_embeds
 
-    def __call__(self, input_ids: mx.array, pixel_values: mx.array, cache=None):
-        input_embddings = self.get_input_embeddings(input_ids, pixel_values)
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array,
+        image_sizes: Optional[mx.array] = None,
+        cache=None,
+    ):
+        input_embddings = self.get_input_embeddings(
+            input_ids, pixel_values, image_sizes=image_sizes
+        )
         logits, cache = self.language_model(
             input_ids, cache=cache, inputs_embeds=input_embddings
         )
@@ -166,3 +289,65 @@ class LlavaModel(nn.Module):
 
         model.load_weights(list(weights.items()))
         return model
+
+
+def select_best_resolution(original_size: tuple, possible_resolutions: list) -> tuple:
+    original_height, original_width = original_size
+    best_fit = None
+    max_effective_resolution = 0
+    min_wasted_resolution = float("inf")
+
+    for height, width in possible_resolutions:
+        scale = min(width / original_width, height / original_height)
+        downscaled_width = int(original_width * scale)
+        downscaled_height = int(original_height * scale)
+        effective_resolution = min(
+            downscaled_width * downscaled_height, original_width * original_height
+        )
+        wasted_resolution = height * width - effective_resolution
+
+        if effective_resolution > max_effective_resolution or (
+            effective_resolution == max_effective_resolution
+            and wasted_resolution < min_wasted_resolution
+        ):
+            max_effective_resolution = effective_resolution
+            min_wasted_resolution = wasted_resolution
+            best_fit = (height, width)
+
+    return best_fit
+
+
+def image_size_to_num_patches(image_size, grid_pinpoints, patch_size: int):
+    if grid_pinpoints is None:
+        return 1
+
+    height, width = select_best_resolution(image_size, grid_pinpoints)
+    num_patches = 0
+    for i in range(0, height, patch_size):
+        for j in range(0, width, patch_size):
+            num_patches += 1
+    return num_patches + 1
+
+
+def get_anyres_image_grid_shape(image_size, grid_pinpoints, patch_size):
+    height, width = select_best_resolution(image_size, grid_pinpoints)
+    return height // patch_size, width // patch_size
+
+
+def unpad_image(tensor, original_size):
+    original_height, original_width = original_size
+    current_height, current_width = tensor.shape[1:]
+
+    original_aspect_ratio = original_width / original_height
+    current_aspect_ratio = current_width / current_height
+
+    if original_aspect_ratio > current_aspect_ratio:
+        scale_factor = current_width / original_width
+        new_height = int(round(original_height * scale_factor, 7))
+        padding = (current_height - new_height) // 2
+        return tensor[:, padding : current_height - padding, :]
+
+    scale_factor = current_height / original_height
+    new_width = int(round(original_width * scale_factor, 7))
+    padding = (current_width - new_width) // 2
+    return tensor[:, :, padding : current_width - padding]

--- a/llava/requirements.txt
+++ b/llava/requirements.txt
@@ -1,6 +1,6 @@
 mlx>=0.8.0
 numpy
-transformers
+transformers>=4.39.1
 torch
 huggingface_hub
 Pillow

--- a/llava/test_llava_next.py
+++ b/llava/test_llava_next.py
@@ -1,0 +1,54 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+
+
+def _module(name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    return module
+
+
+class Module:
+    pass
+
+
+sys.modules["mlx"] = _module("mlx")
+sys.modules["mlx.core"] = _module("mlx.core", array=object)
+sys.modules["mlx.nn"] = _module("mlx.nn", Module=Module)
+sys.modules["huggingface_hub"] = _module(
+    "huggingface_hub", snapshot_download=lambda *args, **kwargs: None
+)
+sys.modules["language"] = _module("language", LanguageModel=object, TextConfig=object)
+sys.modules["vision"] = _module(
+    "vision",
+    VisionConfig=object,
+    VisionModel=_module("VisionModel", sanitize=lambda weights: weights),
+)
+
+spec = importlib.util.spec_from_file_location(
+    "llava_example", Path(__file__).with_name("llava.py")
+)
+llava = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(llava)
+
+
+def test_image_size_to_num_patches_includes_base_patch():
+    num_patches = llava.image_size_to_num_patches(
+        image_size=(48, 64),
+        grid_pinpoints=[[336, 672], [672, 336], [672, 672]],
+        patch_size=336,
+    )
+
+    assert num_patches == 3
+
+
+def test_unpad_image_removes_resized_padding():
+    tensor = np.ones((2, 4, 6))
+    unpadded = llava.unpad_image(tensor, original_size=(2, 6))
+
+    assert unpadded.shape == (2, 2, 6)

--- a/llava/train_lora.py
+++ b/llava/train_lora.py
@@ -1,0 +1,245 @@
+# Copyright © 2024 Apple Inc.
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+import numpy as np
+import requests
+from mlx.utils import tree_flatten
+from PIL import Image
+from transformers import AutoProcessor
+
+from llava import LlavaModel
+
+
+class LoRALinear(nn.Module):
+    @staticmethod
+    def from_linear(linear: nn.Linear, rank: int = 8, scale: float = 20.0):
+        output_dims, input_dims = linear.weight.shape
+        lora_linear = LoRALinear(input_dims, output_dims, rank, scale)
+        lora_linear.linear = linear
+        return lora_linear
+
+    def __init__(self, input_dims: int, output_dims: int, rank: int, scale: float):
+        super().__init__()
+        self.linear = nn.Linear(input_dims, output_dims, bias=False)
+        self.scale = scale
+        bound = 1 / math.sqrt(input_dims)
+        self.lora_a = mx.random.uniform(
+            low=-bound,
+            high=bound,
+            shape=(input_dims, rank),
+        )
+        self.lora_b = mx.zeros(shape=(rank, output_dims))
+
+    def __call__(self, x):
+        dtype = self.linear.weight.dtype
+        y = self.linear(x.astype(dtype))
+        z = (x @ self.lora_a) @ self.lora_b
+        return y + self.scale * z
+
+
+class Dataset:
+    def __init__(self, path):
+        self._data = []
+        with open(path, "r") as fid:
+            for line in fid:
+                self._data.append(json.loads(line))
+
+    def __getitem__(self, idx):
+        return self._data[idx]
+
+    def __len__(self):
+        return len(self._data)
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="Fine-tune LLaVA with LoRA.")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="llava-hf/llava-v1.6-mistral-7b-hf",
+        help="The path to the local model directory or Hugging Face repo.",
+    )
+    parser.add_argument(
+        "--train-data",
+        type=str,
+        required=True,
+        help="JSONL file with image, prompt, and text fields.",
+    )
+    parser.add_argument(
+        "--valid-data",
+        type=str,
+        default=None,
+        help="Optional JSONL validation file.",
+    )
+    parser.add_argument("--iters", type=int, default=1000)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--learning-rate", type=float, default=1e-5)
+    parser.add_argument("--lora-layers", type=int, default=16)
+    parser.add_argument("--lora-rank", type=int, default=8)
+    parser.add_argument("--lora-scale", type=float, default=20.0)
+    parser.add_argument("--steps-per-report", type=int, default=10)
+    parser.add_argument("--steps-per-eval", type=int, default=200)
+    parser.add_argument("--adapter-file", type=str, default="llava_adapters.npz")
+    parser.add_argument("--resume-adapter-file", type=str, default=None)
+    parser.add_argument("--save-every", type=int, default=100)
+    parser.add_argument("--seed", type=int, default=0)
+    return parser
+
+
+def load_image(image_source):
+    if image_source.startswith(("http://", "https://")):
+        response = requests.get(image_source, stream=True)
+        response.raise_for_status()
+        return Image.open(response.raw).convert("RGB")
+    if Path(image_source).is_file():
+        return Image.open(image_source).convert("RGB")
+    raise ValueError(f"The image {image_source} must be a valid URL or file path.")
+
+
+def prepare_example(processor, example):
+    image = load_image(example["image"])
+    prompt = example["prompt"]
+    text = example["text"]
+
+    full_inputs = processor(
+        images=image,
+        text=prompt + text,
+        return_tensors="np",
+    )
+    prompt_inputs = processor(
+        images=image,
+        text=prompt,
+        return_tensors="np",
+    )
+
+    input_ids = full_inputs["input_ids"]
+    prompt_length = prompt_inputs["input_ids"].shape[1]
+    loss_mask = np.zeros((1, input_ids.shape[1] - 1), dtype=np.float32)
+    loss_mask[:, max(prompt_length - 1, 0) :] = 1
+
+    image_sizes = full_inputs.get("image_sizes")
+    image_sizes = mx.array(image_sizes) if image_sizes is not None else None
+
+    return (
+        mx.array(input_ids[:, :-1]),
+        mx.array(input_ids[:, 1:]),
+        mx.array(full_inputs["pixel_values"]),
+        image_sizes,
+        mx.array(loss_mask),
+    )
+
+
+def iterate_batches(dataset, processor, train=False):
+    while True:
+        indices = np.arange(len(dataset))
+        if train:
+            indices = np.random.permutation(indices)
+        for idx in indices:
+            yield prepare_example(processor, dataset[idx])
+        if not train:
+            break
+
+
+def loss(model, input_ids, targets, pixel_values, image_sizes, loss_mask):
+    logits, _ = model(input_ids, pixel_values, image_sizes=image_sizes)
+    logits = logits.astype(mx.float32)
+    ce = nn.losses.cross_entropy(logits, targets) * loss_mask
+    ntoks = loss_mask.sum()
+    return ce.sum() / ntoks, ntoks
+
+
+def evaluate(model, dataset, processor, num_batches=25):
+    losses = []
+    ntokens = 0
+    for _, batch in zip(range(num_batches), iterate_batches(dataset, processor)):
+        batch_loss, toks = loss(model, *batch)
+        losses.append((batch_loss * toks).item())
+        ntokens += toks.item()
+    return np.sum(losses) / ntokens
+
+
+def apply_lora(model, num_layers, rank, scale):
+    model.vision_tower.freeze()
+    model.multi_modal_projector.freeze()
+    model.language_model.freeze()
+
+    layers = model.language_model.model.layers[-num_layers:]
+    for layer in layers:
+        layer.self_attn.q_proj = LoRALinear.from_linear(
+            layer.self_attn.q_proj, rank=rank, scale=scale
+        )
+        layer.self_attn.v_proj = LoRALinear.from_linear(
+            layer.self_attn.v_proj, rank=rank, scale=scale
+        )
+
+
+def train(model, train_set, valid_set, processor, optimizer, args):
+    loss_value_and_grad = nn.value_and_grad(model, loss)
+    losses = []
+
+    for it, batch in zip(
+        range(args.iters),
+        iterate_batches(train_set, processor, train=True),
+    ):
+        (loss_value, _), grad = loss_value_and_grad(model, *batch)
+        optimizer.update(model, grad)
+        mx.eval(model.parameters(), optimizer.state, loss_value)
+
+        losses.append(loss_value.item())
+
+        if (it + 1) % args.steps_per_report == 0:
+            print(f"Iter {it + 1}: Train loss {np.mean(losses):.3f}")
+            losses = []
+
+        if valid_set is not None and (it == 0 or (it + 1) % args.steps_per_eval == 0):
+            val_loss = evaluate(model, valid_set, processor)
+            print(f"Iter {it + 1}: Val loss {val_loss:.3f}")
+
+        if (it + 1) % args.save_every == 0:
+            mx.savez(
+                args.adapter_file, **dict(tree_flatten(model.trainable_parameters()))
+            )
+            print(f"Iter {it + 1}: Saved adapter weights to {args.adapter_file}.")
+
+
+def main():
+    args = build_parser().parse_args()
+    if args.batch_size != 1:
+        raise ValueError("LLaVA LoRA fine-tuning currently supports --batch-size 1.")
+    np.random.seed(args.seed)
+
+    print("Loading model")
+    processor = AutoProcessor.from_pretrained(args.model, use_fast=False)
+    model = LlavaModel.from_pretrained(args.model)
+    apply_lora(model, args.lora_layers, args.lora_rank, args.lora_scale)
+
+    if args.resume_adapter_file is not None:
+        print(f"Loading adapter weights from {args.resume_adapter_file}")
+        model.load_weights(args.resume_adapter_file, strict=False)
+
+    train_set = Dataset(args.train_data)
+    valid_set = Dataset(args.valid_data) if args.valid_data is not None else None
+
+    total_params = sum(v.size for _, v in tree_flatten(model.parameters())) / 10**6
+    trainable_params = (
+        sum(v.size for _, v in tree_flatten(model.trainable_parameters())) / 10**6
+    )
+    print(f"Total parameters {total_params:.3f}M")
+    print(f"Trainable parameters {trainable_params:.3f}M")
+
+    optimizer = optim.Adam(learning_rate=args.learning_rate)
+    train(model, train_set, valid_set, processor, optimizer, args)
+
+    mx.savez(args.adapter_file, **dict(tree_flatten(model.trainable_parameters())))
+    print(f"Saved adapter weights to {args.adapter_file}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add LLaVA-NeXT image feature packing and Mistral text-model compatibility
- add a LLaVA LoRA fine-tuning script that trains language-model adapters while freezing the vision tower and projector
- document LLaVA 1.6 generation and JSONL fine-tuning data format

## Testing
- python3 -m pytest llava/test_llava_next.py -q
- python3 -m py_compile llava/llava.py llava/language.py llava/generate.py llava/train_lora.py llava/test_llava_next.py
- python3 -m black --check llava/llava.py llava/language.py llava/generate.py llava/train_lora.py llava/test_llava_next.py
- python3 -m pre_commit run --files llava/README.md llava/generate.py llava/language.py llava/llava.py llava/requirements.txt llava/test_llava_next.py llava/train_lora.py

Closes #605