### PR TITLE
Implement beam search decoding for Whisper

### DIFF
--- a/whisper/mlx_whisper/decoding.py
+++ b/whisper/mlx_whisper/decoding.py
@@ -143,9 +143,16 @@ class Inference:
 
     def rearrange_kv_cache(self, source_indices):
         """Update the key-value cache according to the updated beams"""
-        # update the key/value cache to contain the selected sequences
+        # update the key/value cache to contain the selected sequences; the cache
+        # mixes self-attention entries (batch = n_audio * n_group) with
+        # cross-attention entries (batch = n_audio, broadcast over the group), so
+        # only arrays whose batch dimension matches the selection are reindexed
         if source_indices != list(range(len(source_indices))):
-            self.kv_cache = tree_map(lambda x: x[source_indices], self.kv_cache)
+            n = len(source_indices)
+            self.kv_cache = tree_map(
+                lambda x: x[source_indices] if x.shape[0] == n else x,
+                self.kv_cache,
+            )
 
     def reset(self):
         self.kv_cache = None
@@ -281,6 +288,144 @@ class GreedyDecoder(TokenDecoder):
         # make sure each sequence has at least one EOT token at the end
         tokens = mx.pad(tokens, [(0, 0), (0, 0), (0, 1)], constant_values=self.eot)
         return tokens, sum_logprobs
+
+
+class BeamSearchDecoder(TokenDecoder):
+    def __init__(
+        self,
+        beam_size: int,
+        eot: int,
+        inference: Inference,
+        patience: Optional[float] = None,
+    ):
+        self.beam_size = beam_size
+        self.eot = eot
+        self.inference = inference
+        self.patience = patience or 1.0
+        self.max_candidates: int = round(beam_size * self.patience)
+        self.finished_sequences = None
+        self._rows = None
+
+        assert (
+            self.max_candidates > 0
+        ), f"Invalid beam size ({beam_size}) or patience ({patience})"
+
+    def reset(self):
+        self.finished_sequences = None
+        self._rows = None
+
+    def update(
+        self, tokens: mx.array, logits: mx.array, sum_logprobs: mx.array
+    ) -> Tuple[mx.array, bool, mx.array]:
+        if tokens.shape[0] % self.beam_size != 0:
+            raise ValueError(f"{tokens.shape}[0] % {self.beam_size} != 0")
+
+        n_audio = tokens.shape[0] // self.beam_size
+        if self.finished_sequences is None:  # for the first update
+            self.finished_sequences = [{} for _ in range(n_audio)]
+
+        # select the top candidates on the device and only move
+        # (beam_size + 1) tokens and log probabilities per beam to the host
+        k = self.beam_size + 1
+        logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        top_indices = mx.argpartition(logprobs, -k, axis=-1)[:, -k:]
+        top_values = mx.take_along_axis(logprobs, top_indices, axis=-1)
+        top_indices = np.array(top_indices)
+        top_values = np.array(top_values)
+        sums = np.array(sum_logprobs)
+
+        # the candidate prefixes are rebuilt in python each step, so reuse them
+        # instead of pulling the whole growing token matrix off the device
+        rows = self._rows
+        if rows is None:
+            rows = np.array(tokens).tolist()
+
+        next_tokens, source_indices, next_sum_logprobs = [], [], []
+        finished_sequences = []
+        for i in range(n_audio):
+            scores, sources, finished = {}, {}, {}
+
+            # STEP 1: calculate the cumulative log probabilities for possible candidates
+            for j in range(self.beam_size):
+                idx = i * self.beam_size + j
+                prefix = rows[idx]
+                for logprob, token in zip(top_values[idx], top_indices[idx]):
+                    new_logprob = float(sums[idx] + logprob)
+                    sequence = tuple(prefix + [int(token)])
+                    scores[sequence] = new_logprob
+                    sources[sequence] = idx
+
+            # STEP 2: rank the candidates and keep the top beam_size sequences for each audio
+            saved = 0
+            for sequence in sorted(scores, key=scores.get, reverse=True):
+                if sequence[-1] == self.eot:
+                    finished[sequence] = scores[sequence]
+                else:
+                    next_sum_logprobs.append(scores[sequence])
+                    next_tokens.append(list(sequence))
+                    source_indices.append(sources[sequence])
+
+                    saved += 1
+                    if saved == self.beam_size:
+                        break
+
+            finished_sequences.append(finished)
+
+        self._rows = next_tokens
+        tokens = mx.array(next_tokens)
+        self.inference.rearrange_kv_cache(source_indices)
+        sum_logprobs = mx.array(next_sum_logprobs)
+
+        # add newly finished sequences to self.finished_sequences
+        assert len(self.finished_sequences) == len(finished_sequences)
+        for previously_finished, newly_finished in zip(
+            self.finished_sequences, finished_sequences
+        ):
+            for seq in sorted(newly_finished, key=newly_finished.get, reverse=True):
+                if len(previously_finished) >= self.max_candidates:
+                    break  # the candidate list is full
+                previously_finished[seq] = newly_finished[seq]
+
+        # mark as completed if all audio has enough number of samples
+        completed = all(
+            len(sequences) >= self.max_candidates
+            for sequences in self.finished_sequences
+        )
+        return tokens, completed, sum_logprobs
+
+    def finalize(self, preceding_tokens: mx.array, sum_logprobs: mx.array):
+        # collect all finished sequences, including patience, and add unfinished ones
+        # if not enough finished ones are collected. the caller slices and truncates
+        # each row at its first EOT token, so rows are padded with EOT to stay
+        # rectangular
+        sums = np.array(sum_logprobs)
+        preceding = np.array(preceding_tokens).tolist()
+        for i, sequences in enumerate(self.finished_sequences):
+            if (
+                len(sequences) < self.beam_size
+            ):  # when not enough sequences are finished
+                for j in list(np.argsort(sums[i]))[::-1]:
+                    sequence = tuple(preceding[i][j] + [self.eot])
+                    sequences.setdefault(sequence, float(sums[i][j]))
+                    if len(sequences) >= self.beam_size:
+                        break
+
+        count = max(len(sequences) for sequences in self.finished_sequences)
+        length = 1 + max(
+            len(seq) for sequences in self.finished_sequences for seq in sequences
+        )
+        tokens = []
+        logprobs = []
+        for sequences in self.finished_sequences:
+            ordered = sorted(sequences.items(), key=lambda kv: kv[1], reverse=True)
+            while len(ordered) < count:
+                ordered.append(ordered[0])
+            tokens.append(
+                [list(seq) + [self.eot] * (length - len(seq)) for seq, _ in ordered]
+            )
+            logprobs.append([score for _, score in ordered])
+
+        return mx.array(tokens), mx.array(logprobs)
 
 
 class LogitFilter:
@@ -434,7 +579,9 @@ class DecodingTask:
 
         # decoder: implements how to select the next tokens, given the autoregressive distribution
         if options.beam_size is not None:
-            raise NotImplementedError("Beam search decoder is not yet implemented")
+            self.decoder = BeamSearchDecoder(
+                options.beam_size, tokenizer.eot, self.inference, options.patience
+            )
         else:
             self.decoder = GreedyDecoder(options.temperature, tokenizer.eot)
 


### PR DESCRIPTION
## What this adds

`DecodingOptions` already accepts `beam_size` and `patience`, and most of the machinery for group decoding exists (batch tiling for `n_group > 1`, `MaximumLikelihoodRanker`, `Inference.rearrange_kv_cache`), but requesting a beam size raises `NotImplementedError`. This PR implements the missing `BeamSearchDecoder`, ported from the reference implementation in openai/whisper and adapted to MLX.

## Implementation notes

- **Device-side top-k**: candidate selection runs on the GPU with `mx.argpartition` + `mx.take_along_axis`, so only `(beam_size + 1)` token ids and log probabilities per beam cross to the host each step, instead of a `(n_batch, n_vocab)` matrix. The beam bookkeeping itself stays in python, like the reference implementation.
- **Host-side prefix reuse**: candidate prefixes are kept between steps instead of pulling the whole growing token matrix off the device every step.
- **Rectangular `finalize`**: finished sequences are padded with EOT so the result matches what `DecodingTask.run` expects before it truncates each row at the first EOT.
- **Cross-attention safe cache rearrange**: `rearrange_kv_cache` reindexed every cached array, but the cache mixes self-attention entries (batch = `n_audio * n_group`) with cross-attention entries (batch = `n_audio`, broadcast over the group). Indexing the cross-attention arrays with beam indices reads out of bounds, which MLX does not bounds-check on the GPU, silently corrupting the decode into nondeterministic garbage. The rearrange now only touches arrays whose batch dimension matches the selection; the cross-attention rows are identical across beams anyway. (This also future-proofs `best_of` style uses that might want to rearrange.)

## Testing

On Apple Silicon (M series), with Arabic and English speech:

- `beam_size=5` at `temperature=0` is deterministic across runs and returns correct transcriptions (previously: `NotImplementedError`).
- Works together with `word_timestamps=True`, `patience`, and the temperature fallback chain (`beam_size` applies at t == 0, `best_of` sampling above, matching openai/whisper).
- `decode` still rejects `beam_size` + `best_of` given together, and `patience` without `beam_size`.
- Wall clock with `whisper-large-v3-turbo` on a 44 s clip: `beam_size=5` was within a few percent of greedy decoding. Smaller models pay relatively more (about 2x on `whisper-small`) because the per-step bookkeeping is a larger share of their forward pass.
- Formatted with black.

Beam search noticeably improves difficult, accented, and dialectal speech compared to greedy decoding (it is what faster-whisper and openai/whisper use by default with `beam_size=5`), so this closes one of the last accuracy gaps between mlx_whisper and those implementations.
