### PR TITLE
Fix stale command examples in cifar and cvae READMEs

### DIFF
--- a/cifar/README.md
+++ b/cifar/README.md
@@ -60,5 +60,5 @@ $ cat >hostfile.json
     {"ssh": "host-to-ssh-to", "ips": ["ip-to-bind-to"]},
     {"ssh": "host-to-ssh-to", "ips": ["ip-to-bind-to"]}
 ]
-$ mlx.launch --verbose --hostfile hostfile.json main.py --batch 256 --epochs 5 --arch resnet20
+$ mlx.launch --verbose --hostfile hostfile.json main.py --batch_size 256 --epochs 5 --arch resnet20
 ```

--- a/cvae/README.md
+++ b/cvae/README.md
@@ -25,7 +25,7 @@ To see the supported options, do `python main.py -h`.
 Training with the default options should give:
 
 ```shell
-$ python train.py 
+$ python main.py 
 Options: 
   Device: GPU
   Seed: 0


### PR DESCRIPTION
Two documented commands don't match the code, one commit each:

1. **cifar**: the distributed-training example runs `main.py --batch 256 --epochs 5 --arch resnet20`, but `main.py`'s parser defines `--batch_size` — the command fails with `unrecognized arguments: --batch 256`. Verified by running `main.py --help` (parser output lists `--batch_size`; no `--batch`).
2. **cvae**: the sample-output block shows `$ python train.py`, but the example's entry point is `main.py` (`train.py` doesn't exist in the directory; the README's own instructions above say `python main.py`).

Both scripts still compile (`python -m py_compile`). A sweep of every other example README's documented flags against each script's argparse definitions found no further mismatches.

Prepared with AI assistance (Claude); both fixes mechanically verified as described.