### PR TITLE
Fix GCN validation and test evaluation

### DIFF
--- a/gcn/main.py
+++ b/gcn/main.py
@@ -26,10 +26,23 @@ def eval_fn(x, y):
     return mx.mean(mx.argmax(x, axis=1) == y)
 
 
+def evaluate(model, x, adj, y, mask):
+    training = model.training
+    model.eval()
+    try:
+        y_hat = model(x, adj)
+        loss = loss_fn(y_hat[mask], y[mask])
+        accuracy = eval_fn(y_hat[mask], y[mask])
+        mx.eval(loss, accuracy)
+    finally:
+        model.train(training)
+    return loss, accuracy
+
+
 def forward_fn(gcn, x, adj, y, train_mask, weight_decay):
     y_hat = gcn(x, adj)
     loss = loss_fn(y_hat[train_mask], y[train_mask], weight_decay, gcn.parameters())
-    return loss, y_hat
+    return loss
 
 
 def main(args):
@@ -54,11 +67,9 @@ def main(args):
     @partial(mx.compile, inputs=state, outputs=state)
     def step():
         loss_and_grad_fn = nn.value_and_grad(gcn, forward_fn)
-        (loss, y_hat), grads = loss_and_grad_fn(
-            gcn, x, adj, y, train_mask, args.weight_decay
-        )
+        loss, grads = loss_and_grad_fn(gcn, x, adj, y, train_mask, args.weight_decay)
         optimizer.update(gcn, grads)
-        return loss, y_hat
+        return loss
 
     best_val_loss = float("inf")
     cnt = 0
@@ -66,12 +77,11 @@ def main(args):
     # Training loop
     for epoch in range(args.epochs):
         tic = time.time()
-        loss, y_hat = step()
+        loss = step()
         mx.eval(state)
 
         # Validation
-        val_loss = loss_fn(y_hat[val_mask], y[val_mask])
-        val_acc = eval_fn(y_hat[val_mask], y[val_mask])
+        val_loss, val_acc = evaluate(gcn, x, adj, y, val_mask)
         toc = time.time()
 
         # Early stopping
@@ -96,9 +106,7 @@ def main(args):
         )
 
     # Test
-    test_y_hat = gcn(x, adj)
-    test_loss = loss_fn(y_hat[test_mask], y[test_mask])
-    test_acc = eval_fn(y_hat[test_mask], y[test_mask])
+    test_loss, test_acc = evaluate(gcn, x, adj, y, test_mask)
 
     print(f"Test loss: {test_loss.item():.3f}  |  Test acc: {test_acc.item():.2f}")
 

--- a/gcn/test.py
+++ b/gcn/test.py
@@ -1,0 +1,38 @@
+import unittest
+
+import mlx.core as mx
+import mlx.nn as nn
+from main import evaluate
+
+
+class ModeSensitiveModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.forward_modes = []
+
+    def __call__(self, x, adj):
+        self.forward_modes.append(self.training)
+        if self.training:
+            return mx.array([[0.0, 1.0], [1.0, 0.0]])
+        return mx.array([[1.0, 0.0], [0.0, 1.0]])
+
+
+class TestEvaluation(unittest.TestCase):
+    def test_evaluate_uses_eval_mode_and_restores_model_state(self):
+        labels = mx.array([0, 1])
+        mask = mx.arange(2)
+
+        for training in (True, False):
+            with self.subTest(training=training):
+                model = ModeSensitiveModel().train(training)
+
+                loss, accuracy = evaluate(model, None, None, labels, mask)
+
+                self.assertEqual(model.forward_modes, [False])
+                self.assertEqual(model.training, training)
+                self.assertAlmostEqual(accuracy.item(), 1.0)
+                self.assertAlmostEqual(loss.item(), 0.31326166, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- evaluate GCN validation and test metrics with the current model parameters in evaluation mode
- restore the model's prior training state after each evaluation
- stop returning full training logits once they are no longer reused
- add a regression test for evaluation mode and state restoration

## Problem

The training step returned logits produced before `optimizer.update` and while Dropout was active. The validation path reused those stale, stochastic logits for early stopping. The test path computed a fresh `test_y_hat`, but then accidentally calculated both metrics from the old training-loop `y_hat` instead.

The new `evaluate` helper temporarily disables training behavior, performs a fresh forward pass with the current parameters, materializes the metrics, and restores the caller's original train/eval state.

## Validation

- `python gcn/test.py`: 1 test passed
- `python gcn/main.py --epochs 5 --patience 5 --hidden_dim 8 --nb_layers 1 --dropout 0.5`: completed Cora training and final evaluation
- `pre-commit run --files gcn/main.py gcn/test.py`: Black and isort passed
- `python -m compileall -q gcn`: passed

In a seeded five-step reproduction, the old pre-update training-mode output reported test loss/accuracy of `1.955827 / 0.199`, while a fresh evaluation-mode pass with the final parameters reported `1.928995 / 0.236`; the maximum logit difference was `0.410258`.
