### PR TITLE
[whisper] Preserve per-file output names in the CLI

### DIFF
--- a/whisper/mlx_whisper/cli.py
+++ b/whisper/mlx_whisper/cli.py
@@ -237,16 +237,16 @@ def main():
             # receive the contents from stdin rather than read a file
             audio_obj = audio.load_audio(from_stdin=True)
 
-            output_name = output_name or "content"
+            file_output_name = output_name or "content"
         else:
-            output_name = output_name or pathlib.Path(audio_obj).stem
+            file_output_name = output_name or pathlib.Path(audio_obj).stem
         try:
             result = transcribe(
                 audio_obj,
                 path_or_hf_repo=path_or_hf_repo,
                 **args,
             )
-            writer(result, output_name, **writer_args)
+            writer(result, file_output_name, **writer_args)
         except Exception as e:
             traceback.print_exc()
             print(f"Skipping {audio_obj} due to {type(e).__name__}: {str(e)}")

--- a/whisper/test_cli.py
+++ b/whisper/test_cli.py
@@ -1,0 +1,42 @@
+import sys
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from mlx_whisper import cli
+
+
+class TestCLI(unittest.TestCase):
+    def test_multiple_audio_files_get_distinct_output_names(self):
+        writer = Mock()
+        transcribe = Mock(return_value={"segments": []})
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            argv = [
+                "mlx_whisper",
+                "first.mp3",
+                "second.mp3",
+                "--output-dir",
+                output_dir,
+                "--verbose",
+                "False",
+            ]
+            with (
+                patch.object(cli, "get_writer", return_value=writer),
+                patch.object(cli, "transcribe", transcribe),
+                patch.object(sys, "argv", argv),
+            ):
+                cli.main()
+
+        self.assertEqual(
+            [call.args[1] for call in writer.call_args_list],
+            ["first", "second"],
+        )
+        self.assertEqual(
+            [call.args[0] for call in transcribe.call_args_list],
+            ["first.mp3", "second.mp3"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1441.

When the `mlx_whisper` CLI receives multiple audio paths without
`--output-name`, derive the output basename independently for each input. The
previous loop mutated `output_name` after the first file, so every later
transcription overwrote the first output. Explicit `--output-name` behavior and
stdin handling are unchanged.

## Testing

- `PYTHONPATH=. .venv/bin/python -m unittest test_cli -v`
- `.venv/bin/pre-commit run --files whisper/mlx_whisper/cli.py whisper/test_cli.py`

The regression test mocks transcription and verifies that two input paths are
written as `first.txt` and `second.txt`.

Implementation and test preparation used AI assistance; the submitting
contributor reviewed the changed lines and owns the behavior validation.
