### PR TITLE
[stable-diffusion] Match diffusers Transformer2D GroupNorm epsilon

### DIFF
--- a/stable_diffusion/stable_diffusion/unet.py
+++ b/stable_diffusion/stable_diffusion/unet.py
@@ -95,7 +95,9 @@ class Transformer2D(nn.Module):
     ):
         super().__init__()
 
-        self.norm = nn.GroupNorm(norm_num_groups, in_channels, pytorch_compatible=True)
+        self.norm = nn.GroupNorm(
+            norm_num_groups, in_channels, eps=1e-6, pytorch_compatible=True
+        )
         self.proj_in = nn.Linear(in_channels, model_dims)
         self.transformer_blocks = [
             TransformerBlock(model_dims, num_heads, memory_dims=encoder_dims)

--- a/stable_diffusion/test_unet.py
+++ b/stable_diffusion/test_unet.py
@@ -1,0 +1,19 @@
+import unittest
+
+from stable_diffusion.unet import Transformer2D
+
+
+class TestTransformer2D(unittest.TestCase):
+    def test_group_norm_matches_diffusers_epsilon(self):
+        transformer = Transformer2D(
+            in_channels=32,
+            model_dims=32,
+            encoder_dims=32,
+            num_heads=4,
+        )
+
+        self.assertEqual(transformer.norm.eps, 1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1434.

`Transformer2D` is shared by the Stable Diffusion UNet, but its input
`GroupNorm` relied on MLX's default `eps=1e-5`. Diffusers' reference
`Transformer2DModel` uses `eps=1e-6`, and the mismatch accumulates through the
UNet. Pass the reference epsilon explicitly while leaving the UNet ResNet and
LayerNorm defaults unchanged.

## Testing

- `cd stable_diffusion && PYTHONPATH=. python -m unittest test_unet -v`
- `pre-commit run --files stable_diffusion/stable_diffusion/unet.py stable_diffusion/test_unet.py`

The regression test constructs a `Transformer2D` without downloading model
weights and asserts that its GroupNorm uses `1e-6`.

Implementation and test preparation used AI assistance; the submitting
contributor reviewed the changed lines and owns the behavior validation.
