### PR TITLE
Add dinov2-mlx reference entry

### DIFF
--- a/dinov2/README.md
+++ b/dinov2/README.md
@@ -1,0 +1,41 @@
+# DINOv2
+
+[dinov2-mlx](https://github.com/bahaehmimdi/dinov2-mlx) runs
+[DINOv2](https://github.com/facebookresearch/dinov2) on Apple Silicon,
+verified against real, unmodified PyTorch at every stage (preprocessing,
+model forward, both fp32 and fp16).
+
+**Note on approach**: unlike the other examples in this repo, this does
+not reimplement DINOv2 natively in `mlx.nn`. It runs the real,
+unmodified `transformers.AutoModel` (`Dinov2Model`) through
+[torch-mlx](https://github.com/bahaehmimdi/torch-mlx) — a from-scratch
+`torch`-API-compatible layer backed by `mlx.core` — so the model
+definition itself is real `transformers` code, not a hand-written port.
+Given that's a different shape of contribution than this repo's usual
+convention (native model + `torch` used only for offline weight
+conversion), this entry is a link to the full implementation and
+results rather than inline code — happy to restructure this however
+maintainers think fits best, or to close this if it's not a good fit
+for the example gallery.
+
+## Results
+
+Verified against real PyTorch: `pooler_output` matches to ~0.32%
+relative error. Beats real PyTorch's own MPS backend by ~1.12-1.15x
+across tested image sizes (both backends timed on the identical full
+pipeline: image → resize → crop → forward). Full write-up, including
+what didn't work, in the linked repo's `BENCHMARK_RESULTS.md`.
+
+```python
+from dinov2_mlx import DINOv2MLX
+from PIL import Image
+
+model = DINOv2MLX()
+out = model.extract_features(Image.open("photo.png"))
+out["pooler_output"]        # (1, 1024) numpy array
+out["last_hidden_state"]    # (1, 257, 1024) numpy array
+```
+
+See [the repo](https://github.com/bahaehmimdi/dinov2-mlx) for install
+instructions, the fp16/`mx.compile` options, and full benchmark
+methodology.


### PR DESCRIPTION
## Summary
Adds a `dinov2/` entry linking to [dinov2-mlx](https://github.com/bahaehmimdi/dinov2-mlx), a DINOv2 port for Apple Silicon verified against real, unmodified PyTorch (correctness and speed both checked with real numbers, not assumed).

**I want to flag upfront that this takes a different approach from this repo's other examples**, and I'm genuinely open to your guidance on whether/how it fits. Every example here (e.g. `clip/`, `segment_anything/`) is a native `mlx.nn` model definition, with `torch` used only for one-time offline weight conversion. `dinov2-mlx` instead runs the real, unmodified `transformers.AutoModel` through [torch-mlx](https://github.com/bahaehmimdi/torch-mlx) (a from-scratch PyTorch-API-compatible layer backed by `mlx.core`) at inference time — so the model code itself is real `transformers`, not a hand-written MLX port. Given that, this PR is a short linking README rather than inline runnable code (every other entry here is self-contained code, so this is unusual on that front too).

If this isn't a fit for the example gallery as-is, totally understand — happy to close this, or restructure it however you think makes more sense.

## Results
- `pooler_output` verified against real PyTorch: ~0.32% relative error (consistent with expected float accumulation noise across 24 layers).
- Beats real PyTorch's own MPS backend by ~1.12-1.15x, both backends timed on the identical full pipeline (image → resize → crop → forward) to avoid a benchmark-asymmetry bug found and fixed in a sibling project's history.
- Full accounting, including negative results, in the linked repo's `BENCHMARK_RESULTS.md`.

## Test plan
- [x] Single new `dinov2/README.md`, no changes to existing files
- [x] Link verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HooZphcpzukceMrdArswsP